### PR TITLE
feat: Set ontake fork height to 1 in all deployments

### DIFF
--- a/packages/protocol/contracts/layer1/based/TaikoL1.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoL1.sol
@@ -305,8 +305,8 @@ contract TaikoL1 is EssentialContract, ITaikoL1, TaikoEvents {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
-            ontakeForkHeight: 374_400 // = 7200 * 52
-         });
+            ontakeForkHeight: 1
+        });
     }
 
     /// @dev chain_pauser is supposed to be a cold wallet.

--- a/packages/protocol/contracts/layer1/devnet/DevnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/devnet/DevnetTaikoL1.sol
@@ -25,7 +25,7 @@ contract DevnetTaikoL1 is TaikoL1 {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000
             }),
-            ontakeForkHeight: 2
+            ontakeForkHeight: 1
         });
     }
 }

--- a/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/hekla/HeklaTaikoL1.sol
@@ -27,7 +27,7 @@ contract HeklaTaikoL1 is TaikoL1 {
                 minGasExcess: 1_340_000_000,
                 maxGasIssuancePerBlock: 600_000_000 // two minutes
              }),
-            ontakeForkHeight: 840_512
+            ontakeForkHeight: 1
         });
     }
 }

--- a/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
+++ b/packages/protocol/contracts/layer1/mainnet/rollup/MainnetTaikoL1.sol
@@ -35,7 +35,7 @@ contract MainnetTaikoL1 is TaikoL1, RollupAddressCache {
                 minGasExcess: 1_340_000_000, // correspond to 0.008847185 gwei basefee
                 maxGasIssuancePerBlock: 600_000_000 // two minutes: 5_000_000 * 120
              }),
-            ontakeForkHeight: 538_304
+            ontakeForkHeight: 1
         });
     }
 

--- a/packages/taiko-client/bindings/encoding/protocol_config.go
+++ b/packages/taiko-client/bindings/encoding/protocol_config.go
@@ -19,7 +19,7 @@ var (
 		LivenessBond:          livenessBond,
 		StateRootSyncInternal: 16,
 		MaxAnchorHeightOffset: 64,
-		OntakeForkHeight:      2,
+		OntakeForkHeight:      1,
 		BaseFeeConfig: bindings.LibSharedDataBaseFeeConfig{
 			AdjustmentQuotient:     8,
 			SharingPctg:            75,
@@ -37,7 +37,7 @@ var (
 		LivenessBond:          livenessBond,
 		StateRootSyncInternal: 16,
 		MaxAnchorHeightOffset: 64,
-		OntakeForkHeight:      840_512,
+		OntakeForkHeight:      1,
 		BaseFeeConfig: bindings.LibSharedDataBaseFeeConfig{
 			AdjustmentQuotient:     8,
 			SharingPctg:            75,
@@ -55,7 +55,7 @@ var (
 		LivenessBond:          livenessBond,
 		StateRootSyncInternal: 16,
 		MaxAnchorHeightOffset: 64,
-		OntakeForkHeight:      538_304,
+		OntakeForkHeight:      1,
 		BaseFeeConfig: bindings.LibSharedDataBaseFeeConfig{
 			AdjustmentQuotient:     8,
 			GasIssuancePerSecond:   5_000_000,

--- a/packages/taiko-client/proposer/transaction_builder/calldata_test.go
+++ b/packages/taiko-client/proposer/transaction_builder/calldata_test.go
@@ -2,13 +2,30 @@ package builder
 
 import (
 	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+
+	"github.com/taikoxyz/taiko-mono/packages/taiko-client/pkg/rpc"
 )
 
 func (s *TransactionBuilderTestSuite) TestBuildCalldata() {
-	tx, err := s.calldataTxBuilder.BuildLegacy(context.Background(), false, []byte{1})
+	state, err := rpc.GetProtocolStateVariables(s.RPCClient.TaikoL1, &bind.CallOpts{Context: context.Background()})
 	s.Nil(err)
-	s.Nil(tx.Blobs)
 
-	_, err = s.calldataTxBuilder.BuildOntake(context.Background(), [][]byte{{1}, {2}})
-	s.Error(err, "ontake transaction builder is not supported before ontake fork")
+	if s.chainConfig.IsOntake(new(big.Int).SetUint64(state.B.NumBlocks)) {
+		tx, err := s.calldataTxBuilder.BuildOntake(context.Background(), [][]byte{{1}, {2}})
+		s.Nil(err)
+		s.Nil(tx.Blobs)
+
+		_, err = s.calldataTxBuilder.BuildLegacy(context.Background(), false, []byte{1})
+		s.Error(err, "legacy transaction builder is not supported after ontake fork")
+	} else {
+		tx, err := s.calldataTxBuilder.BuildLegacy(context.Background(), false, []byte{1})
+		s.Nil(err)
+		s.Nil(tx.Blobs)
+
+		_, err = s.calldataTxBuilder.BuildOntake(context.Background(), [][]byte{{1}, {2}})
+		s.Error(err, "ontake transaction builder is not supported before ontake fork")
+	}
 }

--- a/packages/taiko-client/proposer/transaction_builder/common_test.go
+++ b/packages/taiko-client/proposer/transaction_builder/common_test.go
@@ -19,6 +19,7 @@ type TransactionBuilderTestSuite struct {
 	testutils.ClientTestSuite
 	calldataTxBuilder *CalldataTransactionBuilder
 	blobTxBuiler      *BlobTransactionBuilder
+	chainConfig       *config.ChainConfig
 }
 
 func (s *TransactionBuilderTestSuite) SetupTest() {
@@ -50,6 +51,7 @@ func (s *TransactionBuilderTestSuite) SetupTest() {
 		"test",
 		chainConfig,
 	)
+	s.chainConfig = chainConfig
 }
 
 func (s *TransactionBuilderTestSuite) TestGetParentMetaHash() {


### PR DESCRIPTION
This PR sets the `ontakeForkHeight` config to `1` in all deployment configs. Previously it was discussed that it should be `0`, but as to not add any custom behavior to the ontake logic, it was moved to block `1` - i.e. the block after genesis.