### PR TITLE
feat: Retry sending proof

### DIFF
--- a/packages/taiko-client/prover/proof_submitter/transaction/sender.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/sender.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -78,8 +80,18 @@ func (s *Sender) Send(
 
 	// Send the transaction.
 	txMgr, isPrivate := s.txmgrSelector.Select()
-	receipt, err := txMgr.Send(ctx, *txCandidate)
-	if err != nil {
+	var receipt *types.Receipt
+	if err = backoff.Retry(
+		func() error {
+			var err error
+			receipt, err = txMgr.Send(ctx, *txCandidate)
+			return err
+		},
+		backoff.WithContext(
+			backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+			ctx,
+		),
+	); err != nil {
 		if isPrivate {
 			s.txmgrSelector.RecordPrivateTxMgrFailed()
 		}


### PR DESCRIPTION
This PR adds a retry process when sending a proof, aiming to fix the issue with wrong nonces since proposer and prover addresses are the same.  