### PR TITLE
feat: give entire liveness bond to prover after proving window

### DIFF
--- a/packages/protocol/contracts/layer1/based/LibProving.sol
+++ b/packages/protocol/contracts/layer1/based/LibProving.sol
@@ -620,7 +620,7 @@ library LibProving {
                 } else {
                     // Reward a majority of liveness bond to the actual prover
                     unchecked {
-                        reward += _rewardAfterFriction(_local.livenessBond);
+                        reward += _local.livenessBond;
                     }
                 }
             }


### PR DESCRIPTION
Turns out this version of Taiko already returns a part of the liveness bond to the prover, rest gets burnt. It's Pacaya where they burn the entire amount. Straightforward change in this case.