### PR TITLE
Implement concurrency-safe proof caching in SGX and ZKVM producers

### DIFF
--- a/packages/taiko-client/prover/proof_producer/sgx_producer.go
+++ b/packages/taiko-client/prover/proof_producer/sgx_producer.go
@@ -174,16 +174,16 @@ func (s *SGXProofProducer) RequestProof(
 		// Received error, so mark as in-progress and let it retry
 		cache.lastErr = err
 		if errors.Is(err, errProofGenerating) {
-			log.Info("SGX proof generation in progress, received normal error", "blockID", bid, "error", err)
+			log.Info("SGX proof generation in progress, received normal error (continuing to retry)", "blockID", bid, "error", err)
 			return nil, err
 		} else {
-			log.Info("SGX proof generation in progress, received unknown error", "blockID", bid, "error", err)
+			log.Info("SGX proof generation in progress, received unknown error (continuing to retry)", "blockID", bid, "error", err)
 			return nil, err
 		}
 	}
 
 	// If we got a valid proof:
-	log.Info("SGX proof generation completed", "blockID", bid, "proof", proofBytes)
+	log.Info("SGX proof generation succeeded, changed status to done", "blockID", bid)
 	cache.status = sgxProofStatusDone
 	cache.proof = proofBytes
 	cache.lastErr = nil

--- a/packages/taiko-client/prover/proof_producer/sgx_producer.go
+++ b/packages/taiko-client/prover/proof_producer/sgx_producer.go
@@ -26,8 +26,8 @@ import (
 type sgxProofStatus int
 
 const (
-	sgxProofStatusNew sgxProofStatus = iota
-	sgxProofStatusInProgress
+	sgxProofStatusNew        sgxProofStatus = iota
+	sgxProofStatusInProgress                // indicates the proof is either currently being generated or a previous API request encountered an error
 	sgxProofStatusDone
 )
 

--- a/packages/taiko-client/prover/proof_producer/sgx_producer.go
+++ b/packages/taiko-client/prover/proof_producer/sgx_producer.go
@@ -138,7 +138,14 @@ func (s *SGXProofProducer) RequestProof(
 		s.proofCache[bid] = cache
 	}
 
+	log.Info("============== sgx_producer.go: proof cache", bid, cache.status)
+
+	if cache.status == subProofStatusNew {
+		log.Info("================= hey hey sgx_producer.go: proof new", bid)
+	}
+
 	switch cache.status {
+
 	// case subProofStatusInProgress:
 	// 	// This block is still generating a proof
 	// 	s.cacheMutex.Unlock()
@@ -170,8 +177,7 @@ func (s *SGXProofProducer) RequestProof(
 			Tier:    s.Tier(),
 		}, nil
 
-	case subProofStatusNew:
-	case subProofStatusInProgress:
+	case subProofStatusNew, subProofStatusInProgress:
 		log.Info("================= sgx_producer.go: proof new or in progress", bid)
 
 		// Mark as in-progress, then generate the proof
@@ -192,7 +198,7 @@ func (s *SGXProofProducer) RequestProof(
 				return nil, err
 			} else {
 				log.Info("======================= at sgx_producer.go received bad bad error", err)
-				cache.status = subProofStatusDone
+				// cache.status = subProofStatusDone
 				return nil, err
 			}
 		}
@@ -211,6 +217,9 @@ func (s *SGXProofProducer) RequestProof(
 			Opts:    opts,
 			Tier:    s.Tier(),
 		}, nil
+
+	default:
+		log.Info("================= sgx_producer.go: unhandled status", bid, cache.status)
 	}
 
 	// Should never happen, but just in case:

--- a/packages/taiko-client/prover/proof_producer/zkvm_producer.go
+++ b/packages/taiko-client/prover/proof_producer/zkvm_producer.go
@@ -168,10 +168,14 @@ func (s *ZKvmProofProducer) RequestProof(
 		// Received error, so mark as in-progress and let it retry
 		cache.lastErr = err
 		if errors.Is(err, ErrProofInProgress) || errors.Is(err, ErrRetry) {
-			log.Info("ZK proof generation in progress, received normal error", "key", key, "error", err)
+			log.Info("ZK proof generation in progress, received normal error (continuing to retry)", "key", key, "error", err)
 			return nil, err
 		} else {
-			log.Info("ZK proof generation in progress, received unknown error", "key", key, "error", err, "but continue to retry")
+			log.Info(
+				"ZK proof generation in progress, received unknown error (continuing to retry)",
+				"key", key,
+				"error", err,
+			)
 			return nil, err
 		}
 	}

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -162,6 +162,7 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoBl
 				return nil
 			}
 
+			log.Info("==================== Actually calling RequestProof at proof_submitter.go", "blockID", meta.GetBlockID())
 			result, err := s.proofProducer.RequestProof(
 				ctx,
 				opts,

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -162,7 +162,9 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoBl
 				return nil
 			}
 
-			log.Info("==================== Actually calling RequestProof at proof_submitter.go", "blockID", meta.GetBlockID())
+			log.Info("Requesting proof in polling loop",
+				"blockID", meta.GetBlockID(),
+			)
 			result, err := s.proofProducer.RequestProof(
 				ctx,
 				opts,

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -403,6 +403,7 @@ func (p *Prover) contestProofOp(req *proofProducer.ContestRequestBody) error {
 
 // requestProofOp requests a new proof generation operation.
 func (p *Prover) requestProofOp(meta metadata.TaikoBlockMetaData, minTier uint16) error {
+	log.Info("============================== Requesting new proof at prover.go", "blockID", meta.GetBlockID(), "minTier", meta.GetMinTier())
 	if submitter := p.selectSubmitter(minTier); submitter != nil {
 		if err := submitter.RequestProof(p.ctx, meta); err != nil {
 			log.Error("Request new proof error", "blockID", meta.GetBlockID(), "minTier", meta.GetMinTier(), "error", err)

--- a/packages/taiko-client/prover/prover.go
+++ b/packages/taiko-client/prover/prover.go
@@ -403,7 +403,10 @@ func (p *Prover) contestProofOp(req *proofProducer.ContestRequestBody) error {
 
 // requestProofOp requests a new proof generation operation.
 func (p *Prover) requestProofOp(meta metadata.TaikoBlockMetaData, minTier uint16) error {
-	log.Info("============================== Requesting new proof at prover.go", "blockID", meta.GetBlockID(), "minTier", meta.GetMinTier())
+	log.Info("Requesting new proof",
+		"blockID", meta.GetBlockID(),
+		"minTier", meta.GetMinTier(),
+	)
 	if submitter := p.selectSubmitter(minTier); submitter != nil {
 		if err := submitter.RequestProof(p.ctx, meta); err != nil {
 			log.Error("Request new proof error", "blockID", meta.GetBlockID(), "minTier", meta.GetMinTier(), "error", err)


### PR DESCRIPTION
### Context

In the current design of the `prover-relayer`, it continuously polls various prover APIs every 10 seconds. This polling strategy is intentional, as it accounts for potential network issues and the varying response times of different provers -- some of which may take several hours to complete a proof generation.

### Problem

Previously, the code lacked a mechanism to cache and track the status of in-progress proof generation for each block. This led to redundant proof generation requests for the same block.

The issue can be seen for block 22 in the logs: https://nethermind.grafana.net/goto/WyFUDo0NR?orgId=1

### Solution

This PR introduces concurrency-safe caching mechanisms for both the SGX and ZKVM proof producers. I tested the updated code locally and confirmed that it actually solves the inefficiency described above.