### PR TITLE
Use sync.Map to ensure block proof is only requested once

### DIFF
--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -191,7 +191,7 @@ func (p *Prover) initProofSubmitters(
 					p.cfg.Risc0VerifierAddress,
 					p.cfg.Sp1VerifierAddress,
 				},
-				ProofStates: make(map[uint64]*proofProducer.BlockProofState),
+				ProofStates: proofProducer.NewProofStateManager(),
 			}
 		case encoding.TierGuardianMinorityID:
 			producer = proofProducer.NewGuardianProofProducer(encoding.TierGuardianMinorityID, p.cfg.EnableLivenessBondProof)

--- a/packages/taiko-client/prover/proof_producer/combined_producer.go
+++ b/packages/taiko-client/prover/proof_producer/combined_producer.go
@@ -129,7 +129,15 @@ func (m *ProofStateManager) cleanOldProofStates(latestBlockID *big.Int, blockHis
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	threshold := blockID - blockHistoryLength
+	var threshold uint64
+	if blockID < blockHistoryLength {
+		// Need this to avoid underflow as both variables are of type uint64; otherwise we could
+		// end up deleting all states with a huge threshold.
+		threshold = 0
+	} else {
+		threshold = blockID - blockHistoryLength
+	}
+
 	for key := range m.states {
 		if key < threshold {
 			delete(m.states, key)

--- a/packages/taiko-client/prover/proof_producer/combined_producer.go
+++ b/packages/taiko-client/prover/proof_producer/combined_producer.go
@@ -17,24 +17,143 @@ import (
 	"github.com/taikoxyz/taiko-mono/packages/taiko-client/bindings/metadata"
 )
 
+type BlockProofState struct {
+	verifiedTiers []uint16
+	proofs        []encoding.SubProof
+}
+
+type ProofStateManager struct {
+	mu     sync.Mutex
+	states map[uint64]*BlockProofState
+}
+
+func NewProofStateManager() *ProofStateManager {
+	return &ProofStateManager{
+		states: make(map[uint64]*BlockProofState),
+	}
+}
+
+func (m *ProofStateManager) create(blockID *big.Int) {
+	blockIDUint64 := blockID.Uint64()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.states[blockIDUint64]
+	if !ok {
+		state = &BlockProofState{
+			verifiedTiers: []uint16{},
+			proofs:        []encoding.SubProof{},
+		}
+		m.states[blockIDUint64] = state
+	}
+}
+
+func (m *ProofStateManager) containsTier(blockID *big.Int, tier uint16) bool {
+	blockIDUint64 := blockID.Uint64()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.states[blockIDUint64]
+	if !ok {
+		return false
+	}
+
+	return slices.Contains(state.verifiedTiers, tier)
+}
+
+// addTierAndProof marks the tier as verified and adds the subproof to the block's state if
+// the state has not yet collected enough proofs. It returns whether the required number
+// of proofs has now been reached.
+func (m *ProofStateManager) addTierAndProof(
+	blockID *big.Int,
+	tier uint16,
+	subProof encoding.SubProof,
+	requiredProofs uint8,
+) (reachedRequired bool) {
+	blockIDUint64 := blockID.Uint64()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.states[blockIDUint64]
+	if !ok {
+		// create if it doesn't exist
+		state = &BlockProofState{
+			verifiedTiers: []uint16{},
+			proofs:        []encoding.SubProof{},
+		}
+		m.states[blockIDUint64] = state
+	}
+
+	// Record that we've verified this tier
+	state.verifiedTiers = append(state.verifiedTiers, tier)
+
+	// Only add to the subproofs if we haven't reached requiredProofs count yet
+	if uint8(len(state.proofs)) < requiredProofs {
+		state.proofs = append(state.proofs, subProof)
+	}
+
+	// Return true if we've now collected enough proofs
+	return uint8(len(state.proofs)) == requiredProofs
+}
+
+func (m *ProofStateManager) currentProofCount(blockID *big.Int) int {
+	blockIDUint64 := blockID.Uint64()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.states[blockIDUint64]
+	if !ok {
+		return 0
+	}
+	return len(state.proofs)
+}
+
+func (m *ProofStateManager) encodeSubProofs(blockID *big.Int) ([]byte, error) {
+	blockIDUint64 := blockID.Uint64()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.states[blockIDUint64]
+	if !ok {
+		return nil, fmt.Errorf("block proof state not found for blockID: %d", blockIDUint64)
+	}
+
+	return encoding.EncodeSubProofs(state.proofs)
+}
+
+// cleanOldProofStates removes proof states for blocks older than `blockHistoryLength` blocks.
+func (m *ProofStateManager) cleanOldProofStates(latestBlockID *big.Int, blockHistoryLength uint64) {
+	blockID := latestBlockID.Uint64()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	threshold := blockID - blockHistoryLength
+	for key := range m.states {
+		if key < threshold {
+			delete(m.states, key)
+		}
+	}
+}
+
 // CombinedProducer generates proofs from multiple producers in parallel and combines them.
 type CombinedProducer struct {
 	ProofTier      uint16
 	RequiredProofs uint8
 	Producers      []ProofProducer
 	Verifiers      []common.Address
-	// Map blockID to its proof state
-	ProofStates map[uint64]*BlockProofState
-	mapMutex    sync.Mutex
-}
 
-type BlockProofState struct {
-	verifiedTiers []uint16
-	proofs        []encoding.SubProof
+	// Thread-safe manager for block proof states
+	ProofStates *ProofStateManager
 }
 
 const (
-	// represents the number of blocks to keep in history of proof states
+	// BlockHistoryLength represents the number of blocks to keep in history of proof states.
 	BlockHistoryLength = 256
 )
 
@@ -48,27 +167,31 @@ func (c *CombinedProducer) RequestProof(
 	requestAt time.Time,
 ) (*ProofWithHeader, error) {
 	log.Debug("CombinedProducer: RequestProof", "blockID", blockID, "Producers num", len(c.Producers))
+
 	var (
 		wg         sync.WaitGroup
 		errorsChan = make(chan error, len(c.Producers))
 	)
 
-	proofState := c.getProofState(blockID)
+	// We create the proof state to track progress
+	c.ProofStates.create(blockID)
 
 	taskCtx, taskCtxCancel := context.WithCancel(ctx)
 	defer taskCtxCancel()
 
 	for i, producer := range c.Producers {
-		if proofStateContainsTier(proofState, producer.Tier(), &c.mapMutex) {
-			log.Debug("Skipping producer, proof already verified", "tier", producer.Tier())
+		tier := producer.Tier()
+
+		if c.ProofStates.containsTier(blockID, tier) {
+			log.Debug("Skipping producer, proof already verified", "tier", tier)
 			continue
 		}
 
-		log.Debug("Adding proof producer", "blockID", blockID, "tier", producer.Tier())
+		log.Debug("Adding proof producer", "blockID", blockID, "tier", tier)
 		verifier := c.Verifiers[i]
 
 		wg.Add(1)
-		go func(idx int, p ProofProducer, verifier common.Address) {
+		go func(idx int, p ProofProducer, v common.Address) {
 			defer wg.Done()
 
 			proofWithHeader, err := p.RequestProof(taskCtx, opts, blockID, meta, header, requestAt)
@@ -77,45 +200,34 @@ func (c *CombinedProducer) RequestProof(
 				return
 			}
 
-			c.mapMutex.Lock()
-			defer c.mapMutex.Unlock()
+			reachedRequired := c.ProofStates.addTierAndProof(blockID, p.Tier(), encoding.SubProof{
+				Proof:    proofWithHeader.Proof,
+				Verifier: v,
+			}, c.RequiredProofs)
 
-			proofState.verifiedTiers = append(proofState.verifiedTiers, p.Tier())
-			if uint8(len(proofState.proofs)) < c.RequiredProofs {
-				proofState.proofs = append(
-					proofState.proofs,
-					encoding.SubProof{
-						Proof:    proofWithHeader.Proof,
-						Verifier: verifier,
-					},
-				)
-			}
-
-			if uint8(len(proofState.proofs)) == c.RequiredProofs {
+			if reachedRequired {
 				taskCtxCancel()
 			}
 		}(i, producer, verifier)
 	}
 
 	wg.Wait()
+	close(errorsChan)
 
-	if uint8(len(proofState.proofs)) < c.RequiredProofs {
+	currentProofCount := c.ProofStates.currentProofCount(blockID)
+	if uint8(currentProofCount) < c.RequiredProofs {
+		// Not enough proofs, gather errors
 		var errMsgs []string
-
-		errMsgs = append(
-			errMsgs,
-			fmt.Sprintf("not enough proofs collected: required %d, got %d", c.RequiredProofs, len(proofState.proofs)),
+		errMsgs = append(errMsgs,
+			fmt.Sprintf("not enough proofs collected: required %d, got %d", c.RequiredProofs, currentProofCount),
 		)
-
-		close(errorsChan)
 		for err := range errorsChan {
 			errMsgs = append(errMsgs, err.Error())
 		}
-
 		return nil, fmt.Errorf("combined proof production failed: %s", strings.Join(errMsgs, "; "))
 	}
 
-	combinedProof, err := encoding.EncodeSubProofs(proofState.proofs)
+	combinedProof, err := c.ProofStates.encodeSubProofs(blockID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode sub proofs: %w", err)
 	}
@@ -127,7 +239,7 @@ func (c *CombinedProducer) RequestProof(
 		"producer", "CombinedProducer",
 	)
 
-	c.CleanOldProofStates(blockID)
+	c.ProofStates.cleanOldProofStates(blockID, BlockHistoryLength)
 
 	return &ProofWithHeader{
 		BlockID: blockID,
@@ -137,53 +249,6 @@ func (c *CombinedProducer) RequestProof(
 		Opts:    opts,
 		Tier:    c.Tier(),
 	}, nil
-}
-
-func proofStateContainsTier(proofState *BlockProofState, tier uint16, mutex *sync.Mutex) bool {
-	mutex.Lock()
-	defer mutex.Unlock()
-	return slices.Contains(proofState.verifiedTiers, tier)
-}
-
-// getProofState returns the proof state for the given block ID, creating a new one if it doesn't exist.
-func (c *CombinedProducer) getProofState(blockID *big.Int) *BlockProofState {
-	blockIDUint64 := blockID.Uint64()
-	c.mapMutex.Lock()
-	defer c.mapMutex.Unlock()
-
-	// Get or initialize proof state
-	proofState, ok := c.ProofStates[blockIDUint64]
-	if !ok {
-		proofState = &BlockProofState{
-			verifiedTiers: []uint16{},
-			proofs:        []encoding.SubProof{},
-		}
-		c.ProofStates[blockIDUint64] = proofState
-	}
-
-	return proofState
-}
-
-// CleanOldProofStates removes proof states for blocks older than 256 blocks.
-func (c *CombinedProducer) CleanOldProofStates(latestBlockID *big.Int) {
-	if len(c.ProofStates) == 0 {
-		return
-	}
-
-	blockID := latestBlockID.Uint64()
-	log.Debug("Cleaning old proof states", "latestBlockID", blockID)
-
-	c.mapMutex.Lock()
-	defer c.mapMutex.Unlock()
-
-	delete(c.ProofStates, blockID)
-
-	threshold := blockID - BlockHistoryLength
-	for key := range c.ProofStates {
-		if key < threshold {
-			delete(c.ProofStates, key)
-		}
-	}
 }
 
 // RequestCancel implements the ProofProducer interface.

--- a/packages/taiko-client/prover/proof_producer/combined_producer.go
+++ b/packages/taiko-client/prover/proof_producer/combined_producer.go
@@ -140,6 +140,7 @@ func (m *ProofStateManager) cleanOldProofStates(latestBlockID *big.Int, blockHis
 
 	for key := range m.states {
 		if key < threshold {
+			log.Info("Cleaning old proof state", "blockID", key)
 			delete(m.states, key)
 		}
 	}

--- a/packages/taiko-client/prover/proof_producer/combined_producer.go
+++ b/packages/taiko-client/prover/proof_producer/combined_producer.go
@@ -79,7 +79,6 @@ func (m *ProofStateManager) addTierAndProof(
 
 	state, ok := m.states[blockIDUint64]
 	if !ok {
-		// create if it doesn't exist
 		state = &BlockProofState{
 			verifiedTiers: []uint16{},
 			proofs:        []encoding.SubProof{},
@@ -87,15 +86,12 @@ func (m *ProofStateManager) addTierAndProof(
 		m.states[blockIDUint64] = state
 	}
 
-	// Record that we've verified this tier
 	state.verifiedTiers = append(state.verifiedTiers, tier)
 
-	// Only add to the subproofs if we haven't reached requiredProofs count yet
 	if uint8(len(state.proofs)) < requiredProofs {
 		state.proofs = append(state.proofs, subProof)
 	}
 
-	// Return true if we've now collected enough proofs
 	return uint8(len(state.proofs)) == requiredProofs
 }
 
@@ -173,7 +169,6 @@ func (c *CombinedProducer) RequestProof(
 		errorsChan = make(chan error, len(c.Producers))
 	)
 
-	// We create the proof state to track progress
 	c.ProofStates.create(blockID)
 
 	taskCtx, taskCtxCancel := context.WithCancel(ctx)
@@ -216,7 +211,6 @@ func (c *CombinedProducer) RequestProof(
 
 	currentProofCount := c.ProofStates.currentProofCount(blockID)
 	if uint8(currentProofCount) < c.RequiredProofs {
-		// Not enough proofs, gather errors
 		var errMsgs []string
 		errMsgs = append(errMsgs,
 			fmt.Sprintf("not enough proofs collected: required %d, got %d", c.RequiredProofs, currentProofCount),

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -93,6 +93,8 @@ func NewProofSubmitter(
 
 // RequestProof implements the Submitter interface.
 func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoBlockMetaData) error {
+	log.Debug("Start proof submitter for block", "blockID", meta.GetBlockID())
+
 	var (
 		blockInfo bindings.TaikoDataBlockV2
 	)
@@ -146,6 +148,11 @@ func (s *ProofSubmitter) RequestProof(ctx context.Context, meta metadata.TaikoBl
 	}
 
 	startTime := time.Now()
+
+	log.Info("Starting the polling for proof request at proof submitter",
+		"blockID", opts.BlockID,
+		"interval", proofPollingInterval,
+	)
 
 	// Send the generated proof.
 	if err := backoff.Retry(


### PR DESCRIPTION
This PR aims to solve the potential problem where the `ProofSubmitter.RequestProof()` of the combined proof producer is called multiple times, which sends unnecessary requests to the Raiko prover, consuming unnecessary resources. This can happen for multiple reasons, where events such as a new block proposed, a new block proposed v2, and a proving tricker trigger check for proving the block.

When the problem was noticed, the prover would accept multiple proving requests for the same block, however, the problem can no longer be produced since the prover no longer accepts same proving requests multiple times if one of them is already in progress. 

Since the original issue can no longer be produced, this is being created as a Draft PR.