### PR TITLE
Fix driver_l2Verified_id gauge metric

### DIFF
--- a/packages/taiko-client/driver/state/state.go
+++ b/packages/taiko-client/driver/state/state.go
@@ -170,6 +170,7 @@ func (s *State) eventLoop(ctx context.Context) {
 				"stateRoot", common.Hash(e.StateRoot),
 				"prover", e.Prover,
 			)
+			metrics.DriverL2VerifiedHeightGauge.Set(float64(e.BlockId.Uint64()))
 		case e := <-blockVerifiedV2Ch:
 			log.Info(
 				"📈 Block verified",
@@ -177,6 +178,7 @@ func (s *State) eventLoop(ctx context.Context) {
 				"hash", common.Hash(e.BlockHash),
 				"prover", e.Prover,
 			)
+			metrics.DriverL2VerifiedHeightGauge.Set(float64(e.BlockId.Uint64()))
 		case newHead := <-l1HeadCh:
 			s.setL1Head(newHead)
 			s.l1HeadsFeed.Send(newHead)

--- a/packages/taiko-client/prover/event_handler/block_verified.go
+++ b/packages/taiko-client/prover/event_handler/block_verified.go
@@ -19,7 +19,6 @@ func NewBlockVerifiedEventHandler() *BlockVerifiedEventHandler {
 
 // Handle handles the BlockVerified event.
 func (h *BlockVerifiedEventHandler) Handle(e *bindings.TaikoL1ClientBlockVerifiedV2) {
-	metrics.DriverL2VerifiedHeightGauge.Set(float64(e.BlockId.Uint64()))
 	metrics.ProverLatestVerifiedIDGauge.Set(float64(e.BlockId.Uint64()))
 
 	log.Info(


### PR DESCRIPTION
### Context

We want to use the `driver_l2Verified_id` gauge metric to trigger alerts. Right now, it's always showing zero: https://nethermind.grafana.net/goto/tEFmHf1Hg?orgId=1. The reason is that even though the metric is defined in the code (https://github.com/NethermindEth/surge-taiko-mono/blob/main/packages/taiko-client/internal/metrics/metrics.go#L26), it’s actually not used anywhere in the codebase, so Prometheus always sees it as 0.

### Solution

This PR updates the metric when a block is verified.

In `state.go`, there’s an event loop that listens for block verification events using two channels: `blockVerifiedCh` and `blockVerifiedV2Ch`. From looking at the driver logs (https://nethermind.grafana.net/goto/4B0dNB1HR?orgId=1), it seems that only `blockVerifiedV2Ch` is currently in use, which presumably is the newer V2 of the protocol.

Still, I added the metric update to both channels, just to stay consistent with how things are currently structured and to support older setups if needed.

I also removed a line from an earlier PR https://github.com/NethermindEth/surge-taiko-mono/pull/119 that is no longer needed. For more context, here is the dashboard for prover-relayer logs: https://nethermind.grafana.net/goto/GDfTHBJNR?orgId=1. 