### PR TITLE
[Proposer] Listen to `sendMessage` Calls from Bridge Contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ __pycache__/
 
 # Idea
 .idea/
+
+# Go checksum database
+pkg/sumdb/

--- a/packages/taiko-client/bindings/bridge/Bridge.go
+++ b/packages/taiko-client/bindings/bridge/Bridge.go
@@ -1,0 +1,2615 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package bridge
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// BridgeProcessingStats is an auto generated low-level Go binding around an user-defined struct.
+type BridgeProcessingStats struct {
+	GasUsedInFeeCalc   uint32
+	ProofSize          uint32
+	NumCacheOps        uint32
+	ProcessedByRelayer bool
+}
+
+// IBridgeContext is an auto generated low-level Go binding around an user-defined struct.
+type IBridgeContext struct {
+	MsgHash    [32]byte
+	From       common.Address
+	SrcChainId uint64
+}
+
+// IBridgeMessage is an auto generated low-level Go binding around an user-defined struct.
+type IBridgeMessage struct {
+	Id          uint64
+	Fee         uint64
+	GasLimit    uint32
+	From        common.Address
+	SrcChainId  uint64
+	SrcOwner    common.Address
+	DestChainId uint64
+	DestOwner   common.Address
+	To          common.Address
+	Value       *big.Int
+	Data        []byte
+}
+
+// BridgeMetaData contains all meta data concerning the Bridge contract.
+var BridgeMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"GAS_OVERHEAD\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"GAS_RESERVE\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"RELAYER_MAX_PROOF_BYTES\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"addressManager\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"context\",\"inputs\":[],\"outputs\":[{\"name\":\"ctx_\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Context\",\"components\":[{\"name\":\"msgHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"}]}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"failMessage\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"getMessageMinGasLimit\",\"inputs\":[{\"name\":\"dataLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint32\",\"internalType\":\"uint32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"hashMessage\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"impl\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"inNonReentrant\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"init\",\"inputs\":[{\"name\":\"_owner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"_sharedAddressManager\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"init2\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"isDestChainEnabled\",\"inputs\":[{\"name\":\"_chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"outputs\":[{\"name\":\"enabled_\",\"type\":\"bool\",\"internalType\":\"bool\"},{\"name\":\"destBridge_\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isMessageFailed\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isMessageReceived\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isMessageSent\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"lastUnpausedAt\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"messageStatus\",\"inputs\":[{\"name\":\"msgHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"status\",\"type\":\"uint8\",\"internalType\":\"enumIBridge.Status\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"nextMessageId\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint64\",\"internalType\":\"uint64\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"pause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"paused\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"processMessage\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[{\"name\":\"status_\",\"type\":\"uint8\",\"internalType\":\"enumIBridge.Status\"},{\"name\":\"reason_\",\"type\":\"uint8\",\"internalType\":\"enumIBridge.StatusReason\"}],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"proxiableUUID\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"recallMessage\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"_proof\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"resolve\",\"inputs\":[{\"name\":\"_chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"_name\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"_allowZeroAddress\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"resolve\",\"inputs\":[{\"name\":\"_name\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"_allowZeroAddress\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"retryMessage\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"_isLastAttempt\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"selfDelegate\",\"inputs\":[{\"name\":\"_anyToken\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"sendMessage\",\"inputs\":[{\"name\":\"_message\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"outputs\":[{\"name\":\"msgHash_\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"message_\",\"type\":\"tuple\",\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"stateMutability\":\"payable\"},{\"type\":\"function\",\"name\":\"signalForFailedMessage\",\"inputs\":[{\"name\":\"_msgHash\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"stateMutability\":\"pure\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"unpause\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeTo\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"upgradeToAndCall\",\"inputs\":[{\"name\":\"newImplementation\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}],\"outputs\":[],\"stateMutability\":\"payable\"},{\"type\":\"event\",\"name\":\"AdminChanged\",\"inputs\":[{\"name\":\"previousAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"},{\"name\":\"newAdmin\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"BeaconUpgraded\",\"inputs\":[{\"name\":\"beacon\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Initialized\",\"inputs\":[{\"name\":\"version\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"uint8\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MessageProcessed\",\"inputs\":[{\"name\":\"msgHash\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"message\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]},{\"name\":\"stats\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structBridge.ProcessingStats\",\"components\":[{\"name\":\"gasUsedInFeeCalc\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"proofSize\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"numCacheOps\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"processedByRelayer\",\"type\":\"bool\",\"internalType\":\"bool\"}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MessageSent\",\"inputs\":[{\"name\":\"msgHash\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"message\",\"type\":\"tuple\",\"indexed\":false,\"internalType\":\"structIBridge.Message\",\"components\":[{\"name\":\"id\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"fee\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"gasLimit\",\"type\":\"uint32\",\"internalType\":\"uint32\"},{\"name\":\"from\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"srcChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"srcOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"destChainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"destOwner\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"to\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"value\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"data\",\"type\":\"bytes\",\"internalType\":\"bytes\"}]}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"MessageStatusChanged\",\"inputs\":[{\"name\":\"msgHash\",\"type\":\"bytes32\",\"indexed\":true,\"internalType\":\"bytes32\"},{\"name\":\"status\",\"type\":\"uint8\",\"indexed\":false,\"internalType\":\"enumIBridge.Status\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"OwnershipTransferred\",\"inputs\":[{\"name\":\"previousOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"newOwner\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Paused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Unpaused\",\"inputs\":[{\"name\":\"account\",\"type\":\"address\",\"indexed\":false,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"Upgraded\",\"inputs\":[{\"name\":\"implementation\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"B_INSUFFICIENT_GAS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_INVALID_CHAINID\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_INVALID_CONTEXT\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_INVALID_FEE\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_INVALID_GAS_LIMIT\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_INVALID_STATUS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_INVALID_VALUE\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_MESSAGE_NOT_SENT\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_OUT_OF_ETH_QUOTA\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_PERMISSION_DENIED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_PROOF_TOO_LARGE\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_RETRY_FAILED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"B_SIGNAL_NOT_RECEIVED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ETH_TRANSFER_FAILED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FUNCTION_DISABLED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"FUNC_NOT_IMPLEMENTED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"INVALID_PAUSE_STATUS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"REENTRANT_CALL\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RESOLVER_DENIED\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RESOLVER_INVALID_MANAGER\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RESOLVER_UNEXPECTED_CHAINID\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"RESOLVER_ZERO_ADDR\",\"inputs\":[{\"name\":\"chainId\",\"type\":\"uint64\",\"internalType\":\"uint64\"},{\"name\":\"name\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}]},{\"type\":\"error\",\"name\":\"ZERO_ADDRESS\",\"inputs\":[]},{\"type\":\"error\",\"name\":\"ZERO_VALUE\",\"inputs\":[]}]",
+}
+
+// BridgeABI is the input ABI used to generate the binding from.
+// Deprecated: Use BridgeMetaData.ABI instead.
+var BridgeABI = BridgeMetaData.ABI
+
+// Bridge is an auto generated Go binding around an Ethereum contract.
+type Bridge struct {
+	BridgeCaller     // Read-only binding to the contract
+	BridgeTransactor // Write-only binding to the contract
+	BridgeFilterer   // Log filterer for contract events
+}
+
+// BridgeCaller is an auto generated read-only Go binding around an Ethereum contract.
+type BridgeCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BridgeTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type BridgeTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BridgeFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type BridgeFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// BridgeSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type BridgeSession struct {
+	Contract     *Bridge           // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BridgeCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type BridgeCallerSession struct {
+	Contract *BridgeCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts // Call options to use throughout this session
+}
+
+// BridgeTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type BridgeTransactorSession struct {
+	Contract     *BridgeTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// BridgeRaw is an auto generated low-level Go binding around an Ethereum contract.
+type BridgeRaw struct {
+	Contract *Bridge // Generic contract binding to access the raw methods on
+}
+
+// BridgeCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type BridgeCallerRaw struct {
+	Contract *BridgeCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// BridgeTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type BridgeTransactorRaw struct {
+	Contract *BridgeTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewBridge creates a new instance of Bridge, bound to a specific deployed contract.
+func NewBridge(address common.Address, backend bind.ContractBackend) (*Bridge, error) {
+	contract, err := bindBridge(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Bridge{BridgeCaller: BridgeCaller{contract: contract}, BridgeTransactor: BridgeTransactor{contract: contract}, BridgeFilterer: BridgeFilterer{contract: contract}}, nil
+}
+
+// NewBridgeCaller creates a new read-only instance of Bridge, bound to a specific deployed contract.
+func NewBridgeCaller(address common.Address, caller bind.ContractCaller) (*BridgeCaller, error) {
+	contract, err := bindBridge(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeCaller{contract: contract}, nil
+}
+
+// NewBridgeTransactor creates a new write-only instance of Bridge, bound to a specific deployed contract.
+func NewBridgeTransactor(address common.Address, transactor bind.ContractTransactor) (*BridgeTransactor, error) {
+	contract, err := bindBridge(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeTransactor{contract: contract}, nil
+}
+
+// NewBridgeFilterer creates a new log filterer instance of Bridge, bound to a specific deployed contract.
+func NewBridgeFilterer(address common.Address, filterer bind.ContractFilterer) (*BridgeFilterer, error) {
+	contract, err := bindBridge(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeFilterer{contract: contract}, nil
+}
+
+// bindBridge binds a generic wrapper to an already deployed contract.
+func bindBridge(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := BridgeMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Bridge *BridgeRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Bridge.Contract.BridgeCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Bridge *BridgeRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Bridge.Contract.BridgeTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Bridge *BridgeRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Bridge.Contract.BridgeTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Bridge *BridgeCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Bridge.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Bridge *BridgeTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Bridge.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Bridge *BridgeTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Bridge.Contract.contract.Transact(opts, method, params...)
+}
+
+// GASOVERHEAD is a free data retrieval call binding the contract method 0xa730cdfb.
+//
+// Solidity: function GAS_OVERHEAD() view returns(uint32)
+func (_Bridge *BridgeCaller) GASOVERHEAD(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "GAS_OVERHEAD")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// GASOVERHEAD is a free data retrieval call binding the contract method 0xa730cdfb.
+//
+// Solidity: function GAS_OVERHEAD() view returns(uint32)
+func (_Bridge *BridgeSession) GASOVERHEAD() (uint32, error) {
+	return _Bridge.Contract.GASOVERHEAD(&_Bridge.CallOpts)
+}
+
+// GASOVERHEAD is a free data retrieval call binding the contract method 0xa730cdfb.
+//
+// Solidity: function GAS_OVERHEAD() view returns(uint32)
+func (_Bridge *BridgeCallerSession) GASOVERHEAD() (uint32, error) {
+	return _Bridge.Contract.GASOVERHEAD(&_Bridge.CallOpts)
+}
+
+// GASRESERVE is a free data retrieval call binding the contract method 0xbe880c81.
+//
+// Solidity: function GAS_RESERVE() view returns(uint32)
+func (_Bridge *BridgeCaller) GASRESERVE(opts *bind.CallOpts) (uint32, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "GAS_RESERVE")
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// GASRESERVE is a free data retrieval call binding the contract method 0xbe880c81.
+//
+// Solidity: function GAS_RESERVE() view returns(uint32)
+func (_Bridge *BridgeSession) GASRESERVE() (uint32, error) {
+	return _Bridge.Contract.GASRESERVE(&_Bridge.CallOpts)
+}
+
+// GASRESERVE is a free data retrieval call binding the contract method 0xbe880c81.
+//
+// Solidity: function GAS_RESERVE() view returns(uint32)
+func (_Bridge *BridgeCallerSession) GASRESERVE() (uint32, error) {
+	return _Bridge.Contract.GASRESERVE(&_Bridge.CallOpts)
+}
+
+// RELAYERMAXPROOFBYTES is a free data retrieval call binding the contract method 0x422770fa.
+//
+// Solidity: function RELAYER_MAX_PROOF_BYTES() view returns(uint256)
+func (_Bridge *BridgeCaller) RELAYERMAXPROOFBYTES(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "RELAYER_MAX_PROOF_BYTES")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RELAYERMAXPROOFBYTES is a free data retrieval call binding the contract method 0x422770fa.
+//
+// Solidity: function RELAYER_MAX_PROOF_BYTES() view returns(uint256)
+func (_Bridge *BridgeSession) RELAYERMAXPROOFBYTES() (*big.Int, error) {
+	return _Bridge.Contract.RELAYERMAXPROOFBYTES(&_Bridge.CallOpts)
+}
+
+// RELAYERMAXPROOFBYTES is a free data retrieval call binding the contract method 0x422770fa.
+//
+// Solidity: function RELAYER_MAX_PROOF_BYTES() view returns(uint256)
+func (_Bridge *BridgeCallerSession) RELAYERMAXPROOFBYTES() (*big.Int, error) {
+	return _Bridge.Contract.RELAYERMAXPROOFBYTES(&_Bridge.CallOpts)
+}
+
+// AddressManager is a free data retrieval call binding the contract method 0x3ab76e9f.
+//
+// Solidity: function addressManager() view returns(address)
+func (_Bridge *BridgeCaller) AddressManager(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "addressManager")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// AddressManager is a free data retrieval call binding the contract method 0x3ab76e9f.
+//
+// Solidity: function addressManager() view returns(address)
+func (_Bridge *BridgeSession) AddressManager() (common.Address, error) {
+	return _Bridge.Contract.AddressManager(&_Bridge.CallOpts)
+}
+
+// AddressManager is a free data retrieval call binding the contract method 0x3ab76e9f.
+//
+// Solidity: function addressManager() view returns(address)
+func (_Bridge *BridgeCallerSession) AddressManager() (common.Address, error) {
+	return _Bridge.Contract.AddressManager(&_Bridge.CallOpts)
+}
+
+// Context is a free data retrieval call binding the contract method 0xd0496d6a.
+//
+// Solidity: function context() view returns((bytes32,address,uint64) ctx_)
+func (_Bridge *BridgeCaller) Context(opts *bind.CallOpts) (IBridgeContext, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "context")
+
+	if err != nil {
+		return *new(IBridgeContext), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(IBridgeContext)).(*IBridgeContext)
+
+	return out0, err
+
+}
+
+// Context is a free data retrieval call binding the contract method 0xd0496d6a.
+//
+// Solidity: function context() view returns((bytes32,address,uint64) ctx_)
+func (_Bridge *BridgeSession) Context() (IBridgeContext, error) {
+	return _Bridge.Contract.Context(&_Bridge.CallOpts)
+}
+
+// Context is a free data retrieval call binding the contract method 0xd0496d6a.
+//
+// Solidity: function context() view returns((bytes32,address,uint64) ctx_)
+func (_Bridge *BridgeCallerSession) Context() (IBridgeContext, error) {
+	return _Bridge.Contract.Context(&_Bridge.CallOpts)
+}
+
+// GetMessageMinGasLimit is a free data retrieval call binding the contract method 0x7cbadfaa.
+//
+// Solidity: function getMessageMinGasLimit(uint256 dataLength) pure returns(uint32)
+func (_Bridge *BridgeCaller) GetMessageMinGasLimit(opts *bind.CallOpts, dataLength *big.Int) (uint32, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "getMessageMinGasLimit", dataLength)
+
+	if err != nil {
+		return *new(uint32), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint32)).(*uint32)
+
+	return out0, err
+
+}
+
+// GetMessageMinGasLimit is a free data retrieval call binding the contract method 0x7cbadfaa.
+//
+// Solidity: function getMessageMinGasLimit(uint256 dataLength) pure returns(uint32)
+func (_Bridge *BridgeSession) GetMessageMinGasLimit(dataLength *big.Int) (uint32, error) {
+	return _Bridge.Contract.GetMessageMinGasLimit(&_Bridge.CallOpts, dataLength)
+}
+
+// GetMessageMinGasLimit is a free data retrieval call binding the contract method 0x7cbadfaa.
+//
+// Solidity: function getMessageMinGasLimit(uint256 dataLength) pure returns(uint32)
+func (_Bridge *BridgeCallerSession) GetMessageMinGasLimit(dataLength *big.Int) (uint32, error) {
+	return _Bridge.Contract.GetMessageMinGasLimit(&_Bridge.CallOpts, dataLength)
+}
+
+// HashMessage is a free data retrieval call binding the contract method 0xc012fa77.
+//
+// Solidity: function hashMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) pure returns(bytes32)
+func (_Bridge *BridgeCaller) HashMessage(opts *bind.CallOpts, _message IBridgeMessage) ([32]byte, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "hashMessage", _message)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// HashMessage is a free data retrieval call binding the contract method 0xc012fa77.
+//
+// Solidity: function hashMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) pure returns(bytes32)
+func (_Bridge *BridgeSession) HashMessage(_message IBridgeMessage) ([32]byte, error) {
+	return _Bridge.Contract.HashMessage(&_Bridge.CallOpts, _message)
+}
+
+// HashMessage is a free data retrieval call binding the contract method 0xc012fa77.
+//
+// Solidity: function hashMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) pure returns(bytes32)
+func (_Bridge *BridgeCallerSession) HashMessage(_message IBridgeMessage) ([32]byte, error) {
+	return _Bridge.Contract.HashMessage(&_Bridge.CallOpts, _message)
+}
+
+// Impl is a free data retrieval call binding the contract method 0x8abf6077.
+//
+// Solidity: function impl() view returns(address)
+func (_Bridge *BridgeCaller) Impl(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "impl")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Impl is a free data retrieval call binding the contract method 0x8abf6077.
+//
+// Solidity: function impl() view returns(address)
+func (_Bridge *BridgeSession) Impl() (common.Address, error) {
+	return _Bridge.Contract.Impl(&_Bridge.CallOpts)
+}
+
+// Impl is a free data retrieval call binding the contract method 0x8abf6077.
+//
+// Solidity: function impl() view returns(address)
+func (_Bridge *BridgeCallerSession) Impl() (common.Address, error) {
+	return _Bridge.Contract.Impl(&_Bridge.CallOpts)
+}
+
+// InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
+//
+// Solidity: function inNonReentrant() view returns(bool)
+func (_Bridge *BridgeCaller) InNonReentrant(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "inNonReentrant")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
+//
+// Solidity: function inNonReentrant() view returns(bool)
+func (_Bridge *BridgeSession) InNonReentrant() (bool, error) {
+	return _Bridge.Contract.InNonReentrant(&_Bridge.CallOpts)
+}
+
+// InNonReentrant is a free data retrieval call binding the contract method 0x3075db56.
+//
+// Solidity: function inNonReentrant() view returns(bool)
+func (_Bridge *BridgeCallerSession) InNonReentrant() (bool, error) {
+	return _Bridge.Contract.InNonReentrant(&_Bridge.CallOpts)
+}
+
+// IsDestChainEnabled is a free data retrieval call binding the contract method 0x8e3881a9.
+//
+// Solidity: function isDestChainEnabled(uint64 _chainId) view returns(bool enabled_, address destBridge_)
+func (_Bridge *BridgeCaller) IsDestChainEnabled(opts *bind.CallOpts, _chainId uint64) (struct {
+	Enabled    bool
+	DestBridge common.Address
+}, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "isDestChainEnabled", _chainId)
+
+	outstruct := new(struct {
+		Enabled    bool
+		DestBridge common.Address
+	})
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Enabled = *abi.ConvertType(out[0], new(bool)).(*bool)
+	outstruct.DestBridge = *abi.ConvertType(out[1], new(common.Address)).(*common.Address)
+
+	return *outstruct, err
+
+}
+
+// IsDestChainEnabled is a free data retrieval call binding the contract method 0x8e3881a9.
+//
+// Solidity: function isDestChainEnabled(uint64 _chainId) view returns(bool enabled_, address destBridge_)
+func (_Bridge *BridgeSession) IsDestChainEnabled(_chainId uint64) (struct {
+	Enabled    bool
+	DestBridge common.Address
+}, error) {
+	return _Bridge.Contract.IsDestChainEnabled(&_Bridge.CallOpts, _chainId)
+}
+
+// IsDestChainEnabled is a free data retrieval call binding the contract method 0x8e3881a9.
+//
+// Solidity: function isDestChainEnabled(uint64 _chainId) view returns(bool enabled_, address destBridge_)
+func (_Bridge *BridgeCallerSession) IsDestChainEnabled(_chainId uint64) (struct {
+	Enabled    bool
+	DestBridge common.Address
+}, error) {
+	return _Bridge.Contract.IsDestChainEnabled(&_Bridge.CallOpts, _chainId)
+}
+
+// IsMessageFailed is a free data retrieval call binding the contract method 0x5862f6e1.
+//
+// Solidity: function isMessageFailed((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) view returns(bool)
+func (_Bridge *BridgeCaller) IsMessageFailed(opts *bind.CallOpts, _message IBridgeMessage, _proof []byte) (bool, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "isMessageFailed", _message, _proof)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsMessageFailed is a free data retrieval call binding the contract method 0x5862f6e1.
+//
+// Solidity: function isMessageFailed((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) view returns(bool)
+func (_Bridge *BridgeSession) IsMessageFailed(_message IBridgeMessage, _proof []byte) (bool, error) {
+	return _Bridge.Contract.IsMessageFailed(&_Bridge.CallOpts, _message, _proof)
+}
+
+// IsMessageFailed is a free data retrieval call binding the contract method 0x5862f6e1.
+//
+// Solidity: function isMessageFailed((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) view returns(bool)
+func (_Bridge *BridgeCallerSession) IsMessageFailed(_message IBridgeMessage, _proof []byte) (bool, error) {
+	return _Bridge.Contract.IsMessageFailed(&_Bridge.CallOpts, _message, _proof)
+}
+
+// IsMessageReceived is a free data retrieval call binding the contract method 0xb8acae0e.
+//
+// Solidity: function isMessageReceived((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) view returns(bool)
+func (_Bridge *BridgeCaller) IsMessageReceived(opts *bind.CallOpts, _message IBridgeMessage, _proof []byte) (bool, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "isMessageReceived", _message, _proof)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsMessageReceived is a free data retrieval call binding the contract method 0xb8acae0e.
+//
+// Solidity: function isMessageReceived((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) view returns(bool)
+func (_Bridge *BridgeSession) IsMessageReceived(_message IBridgeMessage, _proof []byte) (bool, error) {
+	return _Bridge.Contract.IsMessageReceived(&_Bridge.CallOpts, _message, _proof)
+}
+
+// IsMessageReceived is a free data retrieval call binding the contract method 0xb8acae0e.
+//
+// Solidity: function isMessageReceived((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) view returns(bool)
+func (_Bridge *BridgeCallerSession) IsMessageReceived(_message IBridgeMessage, _proof []byte) (bool, error) {
+	return _Bridge.Contract.IsMessageReceived(&_Bridge.CallOpts, _message, _proof)
+}
+
+// IsMessageSent is a free data retrieval call binding the contract method 0x60620c6b.
+//
+// Solidity: function isMessageSent((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) view returns(bool)
+func (_Bridge *BridgeCaller) IsMessageSent(opts *bind.CallOpts, _message IBridgeMessage) (bool, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "isMessageSent", _message)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsMessageSent is a free data retrieval call binding the contract method 0x60620c6b.
+//
+// Solidity: function isMessageSent((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) view returns(bool)
+func (_Bridge *BridgeSession) IsMessageSent(_message IBridgeMessage) (bool, error) {
+	return _Bridge.Contract.IsMessageSent(&_Bridge.CallOpts, _message)
+}
+
+// IsMessageSent is a free data retrieval call binding the contract method 0x60620c6b.
+//
+// Solidity: function isMessageSent((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) view returns(bool)
+func (_Bridge *BridgeCallerSession) IsMessageSent(_message IBridgeMessage) (bool, error) {
+	return _Bridge.Contract.IsMessageSent(&_Bridge.CallOpts, _message)
+}
+
+// LastUnpausedAt is a free data retrieval call binding the contract method 0xe07baba6.
+//
+// Solidity: function lastUnpausedAt() view returns(uint64)
+func (_Bridge *BridgeCaller) LastUnpausedAt(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "lastUnpausedAt")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// LastUnpausedAt is a free data retrieval call binding the contract method 0xe07baba6.
+//
+// Solidity: function lastUnpausedAt() view returns(uint64)
+func (_Bridge *BridgeSession) LastUnpausedAt() (uint64, error) {
+	return _Bridge.Contract.LastUnpausedAt(&_Bridge.CallOpts)
+}
+
+// LastUnpausedAt is a free data retrieval call binding the contract method 0xe07baba6.
+//
+// Solidity: function lastUnpausedAt() view returns(uint64)
+func (_Bridge *BridgeCallerSession) LastUnpausedAt() (uint64, error) {
+	return _Bridge.Contract.LastUnpausedAt(&_Bridge.CallOpts)
+}
+
+// MessageStatus is a free data retrieval call binding the contract method 0x3c6cf473.
+//
+// Solidity: function messageStatus(bytes32 msgHash) view returns(uint8 status)
+func (_Bridge *BridgeCaller) MessageStatus(opts *bind.CallOpts, msgHash [32]byte) (uint8, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "messageStatus", msgHash)
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+// MessageStatus is a free data retrieval call binding the contract method 0x3c6cf473.
+//
+// Solidity: function messageStatus(bytes32 msgHash) view returns(uint8 status)
+func (_Bridge *BridgeSession) MessageStatus(msgHash [32]byte) (uint8, error) {
+	return _Bridge.Contract.MessageStatus(&_Bridge.CallOpts, msgHash)
+}
+
+// MessageStatus is a free data retrieval call binding the contract method 0x3c6cf473.
+//
+// Solidity: function messageStatus(bytes32 msgHash) view returns(uint8 status)
+func (_Bridge *BridgeCallerSession) MessageStatus(msgHash [32]byte) (uint8, error) {
+	return _Bridge.Contract.MessageStatus(&_Bridge.CallOpts, msgHash)
+}
+
+// NextMessageId is a free data retrieval call binding the contract method 0xeefbf17e.
+//
+// Solidity: function nextMessageId() view returns(uint64)
+func (_Bridge *BridgeCaller) NextMessageId(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "nextMessageId")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// NextMessageId is a free data retrieval call binding the contract method 0xeefbf17e.
+//
+// Solidity: function nextMessageId() view returns(uint64)
+func (_Bridge *BridgeSession) NextMessageId() (uint64, error) {
+	return _Bridge.Contract.NextMessageId(&_Bridge.CallOpts)
+}
+
+// NextMessageId is a free data retrieval call binding the contract method 0xeefbf17e.
+//
+// Solidity: function nextMessageId() view returns(uint64)
+func (_Bridge *BridgeCallerSession) NextMessageId() (uint64, error) {
+	return _Bridge.Contract.NextMessageId(&_Bridge.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Bridge *BridgeCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Bridge *BridgeSession) Owner() (common.Address, error) {
+	return _Bridge.Contract.Owner(&_Bridge.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_Bridge *BridgeCallerSession) Owner() (common.Address, error) {
+	return _Bridge.Contract.Owner(&_Bridge.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Bridge *BridgeCaller) Paused(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "paused")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Bridge *BridgeSession) Paused() (bool, error) {
+	return _Bridge.Contract.Paused(&_Bridge.CallOpts)
+}
+
+// Paused is a free data retrieval call binding the contract method 0x5c975abb.
+//
+// Solidity: function paused() view returns(bool)
+func (_Bridge *BridgeCallerSession) Paused() (bool, error) {
+	return _Bridge.Contract.Paused(&_Bridge.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Bridge *BridgeCaller) ProxiableUUID(opts *bind.CallOpts) ([32]byte, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "proxiableUUID")
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Bridge *BridgeSession) ProxiableUUID() ([32]byte, error) {
+	return _Bridge.Contract.ProxiableUUID(&_Bridge.CallOpts)
+}
+
+// ProxiableUUID is a free data retrieval call binding the contract method 0x52d1902d.
+//
+// Solidity: function proxiableUUID() view returns(bytes32)
+func (_Bridge *BridgeCallerSession) ProxiableUUID() ([32]byte, error) {
+	return _Bridge.Contract.ProxiableUUID(&_Bridge.CallOpts)
+}
+
+// Resolve is a free data retrieval call binding the contract method 0x3eb6b8cf.
+//
+// Solidity: function resolve(uint64 _chainId, bytes32 _name, bool _allowZeroAddress) view returns(address)
+func (_Bridge *BridgeCaller) Resolve(opts *bind.CallOpts, _chainId uint64, _name [32]byte, _allowZeroAddress bool) (common.Address, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "resolve", _chainId, _name, _allowZeroAddress)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Resolve is a free data retrieval call binding the contract method 0x3eb6b8cf.
+//
+// Solidity: function resolve(uint64 _chainId, bytes32 _name, bool _allowZeroAddress) view returns(address)
+func (_Bridge *BridgeSession) Resolve(_chainId uint64, _name [32]byte, _allowZeroAddress bool) (common.Address, error) {
+	return _Bridge.Contract.Resolve(&_Bridge.CallOpts, _chainId, _name, _allowZeroAddress)
+}
+
+// Resolve is a free data retrieval call binding the contract method 0x3eb6b8cf.
+//
+// Solidity: function resolve(uint64 _chainId, bytes32 _name, bool _allowZeroAddress) view returns(address)
+func (_Bridge *BridgeCallerSession) Resolve(_chainId uint64, _name [32]byte, _allowZeroAddress bool) (common.Address, error) {
+	return _Bridge.Contract.Resolve(&_Bridge.CallOpts, _chainId, _name, _allowZeroAddress)
+}
+
+// Resolve0 is a free data retrieval call binding the contract method 0xa86f9d9e.
+//
+// Solidity: function resolve(bytes32 _name, bool _allowZeroAddress) view returns(address)
+func (_Bridge *BridgeCaller) Resolve0(opts *bind.CallOpts, _name [32]byte, _allowZeroAddress bool) (common.Address, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "resolve0", _name, _allowZeroAddress)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Resolve0 is a free data retrieval call binding the contract method 0xa86f9d9e.
+//
+// Solidity: function resolve(bytes32 _name, bool _allowZeroAddress) view returns(address)
+func (_Bridge *BridgeSession) Resolve0(_name [32]byte, _allowZeroAddress bool) (common.Address, error) {
+	return _Bridge.Contract.Resolve0(&_Bridge.CallOpts, _name, _allowZeroAddress)
+}
+
+// Resolve0 is a free data retrieval call binding the contract method 0xa86f9d9e.
+//
+// Solidity: function resolve(bytes32 _name, bool _allowZeroAddress) view returns(address)
+func (_Bridge *BridgeCallerSession) Resolve0(_name [32]byte, _allowZeroAddress bool) (common.Address, error) {
+	return _Bridge.Contract.Resolve0(&_Bridge.CallOpts, _name, _allowZeroAddress)
+}
+
+// SignalForFailedMessage is a free data retrieval call binding the contract method 0xd1aaa5df.
+//
+// Solidity: function signalForFailedMessage(bytes32 _msgHash) pure returns(bytes32)
+func (_Bridge *BridgeCaller) SignalForFailedMessage(opts *bind.CallOpts, _msgHash [32]byte) ([32]byte, error) {
+	var out []interface{}
+	err := _Bridge.contract.Call(opts, &out, "signalForFailedMessage", _msgHash)
+
+	if err != nil {
+		return *new([32]byte), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([32]byte)).(*[32]byte)
+
+	return out0, err
+
+}
+
+// SignalForFailedMessage is a free data retrieval call binding the contract method 0xd1aaa5df.
+//
+// Solidity: function signalForFailedMessage(bytes32 _msgHash) pure returns(bytes32)
+func (_Bridge *BridgeSession) SignalForFailedMessage(_msgHash [32]byte) ([32]byte, error) {
+	return _Bridge.Contract.SignalForFailedMessage(&_Bridge.CallOpts, _msgHash)
+}
+
+// SignalForFailedMessage is a free data retrieval call binding the contract method 0xd1aaa5df.
+//
+// Solidity: function signalForFailedMessage(bytes32 _msgHash) pure returns(bytes32)
+func (_Bridge *BridgeCallerSession) SignalForFailedMessage(_msgHash [32]byte) ([32]byte, error) {
+	return _Bridge.Contract.SignalForFailedMessage(&_Bridge.CallOpts, _msgHash)
+}
+
+// FailMessage is a paid mutator transaction binding the contract method 0x913b16cb.
+//
+// Solidity: function failMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) returns()
+func (_Bridge *BridgeTransactor) FailMessage(opts *bind.TransactOpts, _message IBridgeMessage) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "failMessage", _message)
+}
+
+// FailMessage is a paid mutator transaction binding the contract method 0x913b16cb.
+//
+// Solidity: function failMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) returns()
+func (_Bridge *BridgeSession) FailMessage(_message IBridgeMessage) (*types.Transaction, error) {
+	return _Bridge.Contract.FailMessage(&_Bridge.TransactOpts, _message)
+}
+
+// FailMessage is a paid mutator transaction binding the contract method 0x913b16cb.
+//
+// Solidity: function failMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) returns()
+func (_Bridge *BridgeTransactorSession) FailMessage(_message IBridgeMessage) (*types.Transaction, error) {
+	return _Bridge.Contract.FailMessage(&_Bridge.TransactOpts, _message)
+}
+
+// Init is a paid mutator transaction binding the contract method 0xf09a4016.
+//
+// Solidity: function init(address _owner, address _sharedAddressManager) returns()
+func (_Bridge *BridgeTransactor) Init(opts *bind.TransactOpts, _owner common.Address, _sharedAddressManager common.Address) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "init", _owner, _sharedAddressManager)
+}
+
+// Init is a paid mutator transaction binding the contract method 0xf09a4016.
+//
+// Solidity: function init(address _owner, address _sharedAddressManager) returns()
+func (_Bridge *BridgeSession) Init(_owner common.Address, _sharedAddressManager common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.Init(&_Bridge.TransactOpts, _owner, _sharedAddressManager)
+}
+
+// Init is a paid mutator transaction binding the contract method 0xf09a4016.
+//
+// Solidity: function init(address _owner, address _sharedAddressManager) returns()
+func (_Bridge *BridgeTransactorSession) Init(_owner common.Address, _sharedAddressManager common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.Init(&_Bridge.TransactOpts, _owner, _sharedAddressManager)
+}
+
+// Init2 is a paid mutator transaction binding the contract method 0x069489a2.
+//
+// Solidity: function init2() returns()
+func (_Bridge *BridgeTransactor) Init2(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "init2")
+}
+
+// Init2 is a paid mutator transaction binding the contract method 0x069489a2.
+//
+// Solidity: function init2() returns()
+func (_Bridge *BridgeSession) Init2() (*types.Transaction, error) {
+	return _Bridge.Contract.Init2(&_Bridge.TransactOpts)
+}
+
+// Init2 is a paid mutator transaction binding the contract method 0x069489a2.
+//
+// Solidity: function init2() returns()
+func (_Bridge *BridgeTransactorSession) Init2() (*types.Transaction, error) {
+	return _Bridge.Contract.Init2(&_Bridge.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Bridge *BridgeTransactor) Pause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "pause")
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Bridge *BridgeSession) Pause() (*types.Transaction, error) {
+	return _Bridge.Contract.Pause(&_Bridge.TransactOpts)
+}
+
+// Pause is a paid mutator transaction binding the contract method 0x8456cb59.
+//
+// Solidity: function pause() returns()
+func (_Bridge *BridgeTransactorSession) Pause() (*types.Transaction, error) {
+	return _Bridge.Contract.Pause(&_Bridge.TransactOpts)
+}
+
+// ProcessMessage is a paid mutator transaction binding the contract method 0x2035065e.
+//
+// Solidity: function processMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) returns(uint8 status_, uint8 reason_)
+func (_Bridge *BridgeTransactor) ProcessMessage(opts *bind.TransactOpts, _message IBridgeMessage, _proof []byte) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "processMessage", _message, _proof)
+}
+
+// ProcessMessage is a paid mutator transaction binding the contract method 0x2035065e.
+//
+// Solidity: function processMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) returns(uint8 status_, uint8 reason_)
+func (_Bridge *BridgeSession) ProcessMessage(_message IBridgeMessage, _proof []byte) (*types.Transaction, error) {
+	return _Bridge.Contract.ProcessMessage(&_Bridge.TransactOpts, _message, _proof)
+}
+
+// ProcessMessage is a paid mutator transaction binding the contract method 0x2035065e.
+//
+// Solidity: function processMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) returns(uint8 status_, uint8 reason_)
+func (_Bridge *BridgeTransactorSession) ProcessMessage(_message IBridgeMessage, _proof []byte) (*types.Transaction, error) {
+	return _Bridge.Contract.ProcessMessage(&_Bridge.TransactOpts, _message, _proof)
+}
+
+// RecallMessage is a paid mutator transaction binding the contract method 0x9efc7a2e.
+//
+// Solidity: function recallMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) returns()
+func (_Bridge *BridgeTransactor) RecallMessage(opts *bind.TransactOpts, _message IBridgeMessage, _proof []byte) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "recallMessage", _message, _proof)
+}
+
+// RecallMessage is a paid mutator transaction binding the contract method 0x9efc7a2e.
+//
+// Solidity: function recallMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) returns()
+func (_Bridge *BridgeSession) RecallMessage(_message IBridgeMessage, _proof []byte) (*types.Transaction, error) {
+	return _Bridge.Contract.RecallMessage(&_Bridge.TransactOpts, _message, _proof)
+}
+
+// RecallMessage is a paid mutator transaction binding the contract method 0x9efc7a2e.
+//
+// Solidity: function recallMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bytes _proof) returns()
+func (_Bridge *BridgeTransactorSession) RecallMessage(_message IBridgeMessage, _proof []byte) (*types.Transaction, error) {
+	return _Bridge.Contract.RecallMessage(&_Bridge.TransactOpts, _message, _proof)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Bridge *BridgeTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Bridge *BridgeSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Bridge.Contract.RenounceOwnership(&_Bridge.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_Bridge *BridgeTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _Bridge.Contract.RenounceOwnership(&_Bridge.TransactOpts)
+}
+
+// RetryMessage is a paid mutator transaction binding the contract method 0x0432873c.
+//
+// Solidity: function retryMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bool _isLastAttempt) returns()
+func (_Bridge *BridgeTransactor) RetryMessage(opts *bind.TransactOpts, _message IBridgeMessage, _isLastAttempt bool) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "retryMessage", _message, _isLastAttempt)
+}
+
+// RetryMessage is a paid mutator transaction binding the contract method 0x0432873c.
+//
+// Solidity: function retryMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bool _isLastAttempt) returns()
+func (_Bridge *BridgeSession) RetryMessage(_message IBridgeMessage, _isLastAttempt bool) (*types.Transaction, error) {
+	return _Bridge.Contract.RetryMessage(&_Bridge.TransactOpts, _message, _isLastAttempt)
+}
+
+// RetryMessage is a paid mutator transaction binding the contract method 0x0432873c.
+//
+// Solidity: function retryMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message, bool _isLastAttempt) returns()
+func (_Bridge *BridgeTransactorSession) RetryMessage(_message IBridgeMessage, _isLastAttempt bool) (*types.Transaction, error) {
+	return _Bridge.Contract.RetryMessage(&_Bridge.TransactOpts, _message, _isLastAttempt)
+}
+
+// SelfDelegate is a paid mutator transaction binding the contract method 0x82b5e889.
+//
+// Solidity: function selfDelegate(address _anyToken) returns()
+func (_Bridge *BridgeTransactor) SelfDelegate(opts *bind.TransactOpts, _anyToken common.Address) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "selfDelegate", _anyToken)
+}
+
+// SelfDelegate is a paid mutator transaction binding the contract method 0x82b5e889.
+//
+// Solidity: function selfDelegate(address _anyToken) returns()
+func (_Bridge *BridgeSession) SelfDelegate(_anyToken common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.SelfDelegate(&_Bridge.TransactOpts, _anyToken)
+}
+
+// SelfDelegate is a paid mutator transaction binding the contract method 0x82b5e889.
+//
+// Solidity: function selfDelegate(address _anyToken) returns()
+func (_Bridge *BridgeTransactorSession) SelfDelegate(_anyToken common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.SelfDelegate(&_Bridge.TransactOpts, _anyToken)
+}
+
+// SendMessage is a paid mutator transaction binding the contract method 0x1bdb0037.
+//
+// Solidity: function sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) payable returns(bytes32 msgHash_, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message_)
+func (_Bridge *BridgeTransactor) SendMessage(opts *bind.TransactOpts, _message IBridgeMessage) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "sendMessage", _message)
+}
+
+// SendMessage is a paid mutator transaction binding the contract method 0x1bdb0037.
+//
+// Solidity: function sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) payable returns(bytes32 msgHash_, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message_)
+func (_Bridge *BridgeSession) SendMessage(_message IBridgeMessage) (*types.Transaction, error) {
+	return _Bridge.Contract.SendMessage(&_Bridge.TransactOpts, _message)
+}
+
+// SendMessage is a paid mutator transaction binding the contract method 0x1bdb0037.
+//
+// Solidity: function sendMessage((uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) _message) payable returns(bytes32 msgHash_, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message_)
+func (_Bridge *BridgeTransactorSession) SendMessage(_message IBridgeMessage) (*types.Transaction, error) {
+	return _Bridge.Contract.SendMessage(&_Bridge.TransactOpts, _message)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Bridge *BridgeTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Bridge *BridgeSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.TransferOwnership(&_Bridge.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_Bridge *BridgeTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.TransferOwnership(&_Bridge.TransactOpts, newOwner)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Bridge *BridgeTransactor) Unpause(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "unpause")
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Bridge *BridgeSession) Unpause() (*types.Transaction, error) {
+	return _Bridge.Contract.Unpause(&_Bridge.TransactOpts)
+}
+
+// Unpause is a paid mutator transaction binding the contract method 0x3f4ba83a.
+//
+// Solidity: function unpause() returns()
+func (_Bridge *BridgeTransactorSession) Unpause() (*types.Transaction, error) {
+	return _Bridge.Contract.Unpause(&_Bridge.TransactOpts)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_Bridge *BridgeTransactor) UpgradeTo(opts *bind.TransactOpts, newImplementation common.Address) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "upgradeTo", newImplementation)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_Bridge *BridgeSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.UpgradeTo(&_Bridge.TransactOpts, newImplementation)
+}
+
+// UpgradeTo is a paid mutator transaction binding the contract method 0x3659cfe6.
+//
+// Solidity: function upgradeTo(address newImplementation) returns()
+func (_Bridge *BridgeTransactorSession) UpgradeTo(newImplementation common.Address) (*types.Transaction, error) {
+	return _Bridge.Contract.UpgradeTo(&_Bridge.TransactOpts, newImplementation)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Bridge *BridgeTransactor) UpgradeToAndCall(opts *bind.TransactOpts, newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Bridge.contract.Transact(opts, "upgradeToAndCall", newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Bridge *BridgeSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Bridge.Contract.UpgradeToAndCall(&_Bridge.TransactOpts, newImplementation, data)
+}
+
+// UpgradeToAndCall is a paid mutator transaction binding the contract method 0x4f1ef286.
+//
+// Solidity: function upgradeToAndCall(address newImplementation, bytes data) payable returns()
+func (_Bridge *BridgeTransactorSession) UpgradeToAndCall(newImplementation common.Address, data []byte) (*types.Transaction, error) {
+	return _Bridge.Contract.UpgradeToAndCall(&_Bridge.TransactOpts, newImplementation, data)
+}
+
+// BridgeAdminChangedIterator is returned from FilterAdminChanged and is used to iterate over the raw logs and unpacked data for AdminChanged events raised by the Bridge contract.
+type BridgeAdminChangedIterator struct {
+	Event *BridgeAdminChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeAdminChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeAdminChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeAdminChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeAdminChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeAdminChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeAdminChanged represents a AdminChanged event raised by the Bridge contract.
+type BridgeAdminChanged struct {
+	PreviousAdmin common.Address
+	NewAdmin      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterAdminChanged is a free log retrieval operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_Bridge *BridgeFilterer) FilterAdminChanged(opts *bind.FilterOpts) (*BridgeAdminChangedIterator, error) {
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeAdminChangedIterator{contract: _Bridge.contract, event: "AdminChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchAdminChanged is a free log subscription operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_Bridge *BridgeFilterer) WatchAdminChanged(opts *bind.WatchOpts, sink chan<- *BridgeAdminChanged) (event.Subscription, error) {
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "AdminChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeAdminChanged)
+				if err := _Bridge.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseAdminChanged is a log parse operation binding the contract event 0x7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f.
+//
+// Solidity: event AdminChanged(address previousAdmin, address newAdmin)
+func (_Bridge *BridgeFilterer) ParseAdminChanged(log types.Log) (*BridgeAdminChanged, error) {
+	event := new(BridgeAdminChanged)
+	if err := _Bridge.contract.UnpackLog(event, "AdminChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeBeaconUpgradedIterator is returned from FilterBeaconUpgraded and is used to iterate over the raw logs and unpacked data for BeaconUpgraded events raised by the Bridge contract.
+type BridgeBeaconUpgradedIterator struct {
+	Event *BridgeBeaconUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeBeaconUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeBeaconUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeBeaconUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeBeaconUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeBeaconUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeBeaconUpgraded represents a BeaconUpgraded event raised by the Bridge contract.
+type BridgeBeaconUpgraded struct {
+	Beacon common.Address
+	Raw    types.Log // Blockchain specific contextual infos
+}
+
+// FilterBeaconUpgraded is a free log retrieval operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_Bridge *BridgeFilterer) FilterBeaconUpgraded(opts *bind.FilterOpts, beacon []common.Address) (*BridgeBeaconUpgradedIterator, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeBeaconUpgradedIterator{contract: _Bridge.contract, event: "BeaconUpgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchBeaconUpgraded is a free log subscription operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_Bridge *BridgeFilterer) WatchBeaconUpgraded(opts *bind.WatchOpts, sink chan<- *BridgeBeaconUpgraded, beacon []common.Address) (event.Subscription, error) {
+
+	var beaconRule []interface{}
+	for _, beaconItem := range beacon {
+		beaconRule = append(beaconRule, beaconItem)
+	}
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "BeaconUpgraded", beaconRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeBeaconUpgraded)
+				if err := _Bridge.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBeaconUpgraded is a log parse operation binding the contract event 0x1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e.
+//
+// Solidity: event BeaconUpgraded(address indexed beacon)
+func (_Bridge *BridgeFilterer) ParseBeaconUpgraded(log types.Log) (*BridgeBeaconUpgraded, error) {
+	event := new(BridgeBeaconUpgraded)
+	if err := _Bridge.contract.UnpackLog(event, "BeaconUpgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeInitializedIterator is returned from FilterInitialized and is used to iterate over the raw logs and unpacked data for Initialized events raised by the Bridge contract.
+type BridgeInitializedIterator struct {
+	Event *BridgeInitialized // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeInitializedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeInitialized)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeInitialized)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeInitializedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeInitializedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeInitialized represents a Initialized event raised by the Bridge contract.
+type BridgeInitialized struct {
+	Version uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterInitialized is a free log retrieval operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_Bridge *BridgeFilterer) FilterInitialized(opts *bind.FilterOpts) (*BridgeInitializedIterator, error) {
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeInitializedIterator{contract: _Bridge.contract, event: "Initialized", logs: logs, sub: sub}, nil
+}
+
+// WatchInitialized is a free log subscription operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_Bridge *BridgeFilterer) WatchInitialized(opts *bind.WatchOpts, sink chan<- *BridgeInitialized) (event.Subscription, error) {
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "Initialized")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeInitialized)
+				if err := _Bridge.contract.UnpackLog(event, "Initialized", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseInitialized is a log parse operation binding the contract event 0x7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb3847402498.
+//
+// Solidity: event Initialized(uint8 version)
+func (_Bridge *BridgeFilterer) ParseInitialized(log types.Log) (*BridgeInitialized, error) {
+	event := new(BridgeInitialized)
+	if err := _Bridge.contract.UnpackLog(event, "Initialized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeMessageProcessedIterator is returned from FilterMessageProcessed and is used to iterate over the raw logs and unpacked data for MessageProcessed events raised by the Bridge contract.
+type BridgeMessageProcessedIterator struct {
+	Event *BridgeMessageProcessed // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeMessageProcessedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeMessageProcessed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeMessageProcessed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeMessageProcessedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeMessageProcessedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeMessageProcessed represents a MessageProcessed event raised by the Bridge contract.
+type BridgeMessageProcessed struct {
+	MsgHash [32]byte
+	Message IBridgeMessage
+	Stats   BridgeProcessingStats
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterMessageProcessed is a free log retrieval operation binding the contract event 0x8580f507761043ecdd2bdca084d6fb0109150b3d9842d854d34e3dea6d69387d.
+//
+// Solidity: event MessageProcessed(bytes32 indexed msgHash, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message, (uint32,uint32,uint32,bool) stats)
+func (_Bridge *BridgeFilterer) FilterMessageProcessed(opts *bind.FilterOpts, msgHash [][32]byte) (*BridgeMessageProcessedIterator, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "MessageProcessed", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeMessageProcessedIterator{contract: _Bridge.contract, event: "MessageProcessed", logs: logs, sub: sub}, nil
+}
+
+// WatchMessageProcessed is a free log subscription operation binding the contract event 0x8580f507761043ecdd2bdca084d6fb0109150b3d9842d854d34e3dea6d69387d.
+//
+// Solidity: event MessageProcessed(bytes32 indexed msgHash, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message, (uint32,uint32,uint32,bool) stats)
+func (_Bridge *BridgeFilterer) WatchMessageProcessed(opts *bind.WatchOpts, sink chan<- *BridgeMessageProcessed, msgHash [][32]byte) (event.Subscription, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "MessageProcessed", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeMessageProcessed)
+				if err := _Bridge.contract.UnpackLog(event, "MessageProcessed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMessageProcessed is a log parse operation binding the contract event 0x8580f507761043ecdd2bdca084d6fb0109150b3d9842d854d34e3dea6d69387d.
+//
+// Solidity: event MessageProcessed(bytes32 indexed msgHash, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message, (uint32,uint32,uint32,bool) stats)
+func (_Bridge *BridgeFilterer) ParseMessageProcessed(log types.Log) (*BridgeMessageProcessed, error) {
+	event := new(BridgeMessageProcessed)
+	if err := _Bridge.contract.UnpackLog(event, "MessageProcessed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeMessageSentIterator is returned from FilterMessageSent and is used to iterate over the raw logs and unpacked data for MessageSent events raised by the Bridge contract.
+type BridgeMessageSentIterator struct {
+	Event *BridgeMessageSent // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeMessageSentIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeMessageSent)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeMessageSent)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeMessageSentIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeMessageSentIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeMessageSent represents a MessageSent event raised by the Bridge contract.
+type BridgeMessageSent struct {
+	MsgHash [32]byte
+	Message IBridgeMessage
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterMessageSent is a free log retrieval operation binding the contract event 0xe33fd33b4f45b95b1c196242240c5b5233129d724b578f95b66ce8d8aae93517.
+//
+// Solidity: event MessageSent(bytes32 indexed msgHash, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message)
+func (_Bridge *BridgeFilterer) FilterMessageSent(opts *bind.FilterOpts, msgHash [][32]byte) (*BridgeMessageSentIterator, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "MessageSent", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeMessageSentIterator{contract: _Bridge.contract, event: "MessageSent", logs: logs, sub: sub}, nil
+}
+
+// WatchMessageSent is a free log subscription operation binding the contract event 0xe33fd33b4f45b95b1c196242240c5b5233129d724b578f95b66ce8d8aae93517.
+//
+// Solidity: event MessageSent(bytes32 indexed msgHash, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message)
+func (_Bridge *BridgeFilterer) WatchMessageSent(opts *bind.WatchOpts, sink chan<- *BridgeMessageSent, msgHash [][32]byte) (event.Subscription, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "MessageSent", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeMessageSent)
+				if err := _Bridge.contract.UnpackLog(event, "MessageSent", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMessageSent is a log parse operation binding the contract event 0xe33fd33b4f45b95b1c196242240c5b5233129d724b578f95b66ce8d8aae93517.
+//
+// Solidity: event MessageSent(bytes32 indexed msgHash, (uint64,uint64,uint32,address,uint64,address,uint64,address,address,uint256,bytes) message)
+func (_Bridge *BridgeFilterer) ParseMessageSent(log types.Log) (*BridgeMessageSent, error) {
+	event := new(BridgeMessageSent)
+	if err := _Bridge.contract.UnpackLog(event, "MessageSent", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeMessageStatusChangedIterator is returned from FilterMessageStatusChanged and is used to iterate over the raw logs and unpacked data for MessageStatusChanged events raised by the Bridge contract.
+type BridgeMessageStatusChangedIterator struct {
+	Event *BridgeMessageStatusChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeMessageStatusChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeMessageStatusChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeMessageStatusChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeMessageStatusChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeMessageStatusChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeMessageStatusChanged represents a MessageStatusChanged event raised by the Bridge contract.
+type BridgeMessageStatusChanged struct {
+	MsgHash [32]byte
+	Status  uint8
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterMessageStatusChanged is a free log retrieval operation binding the contract event 0x6c51882bc2ed67617f77a1e9b9a25d2caad8448647ecb093b357a603b2575634.
+//
+// Solidity: event MessageStatusChanged(bytes32 indexed msgHash, uint8 status)
+func (_Bridge *BridgeFilterer) FilterMessageStatusChanged(opts *bind.FilterOpts, msgHash [][32]byte) (*BridgeMessageStatusChangedIterator, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "MessageStatusChanged", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeMessageStatusChangedIterator{contract: _Bridge.contract, event: "MessageStatusChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchMessageStatusChanged is a free log subscription operation binding the contract event 0x6c51882bc2ed67617f77a1e9b9a25d2caad8448647ecb093b357a603b2575634.
+//
+// Solidity: event MessageStatusChanged(bytes32 indexed msgHash, uint8 status)
+func (_Bridge *BridgeFilterer) WatchMessageStatusChanged(opts *bind.WatchOpts, sink chan<- *BridgeMessageStatusChanged, msgHash [][32]byte) (event.Subscription, error) {
+
+	var msgHashRule []interface{}
+	for _, msgHashItem := range msgHash {
+		msgHashRule = append(msgHashRule, msgHashItem)
+	}
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "MessageStatusChanged", msgHashRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeMessageStatusChanged)
+				if err := _Bridge.contract.UnpackLog(event, "MessageStatusChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMessageStatusChanged is a log parse operation binding the contract event 0x6c51882bc2ed67617f77a1e9b9a25d2caad8448647ecb093b357a603b2575634.
+//
+// Solidity: event MessageStatusChanged(bytes32 indexed msgHash, uint8 status)
+func (_Bridge *BridgeFilterer) ParseMessageStatusChanged(log types.Log) (*BridgeMessageStatusChanged, error) {
+	event := new(BridgeMessageStatusChanged)
+	if err := _Bridge.contract.UnpackLog(event, "MessageStatusChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Bridge contract.
+type BridgeOwnershipTransferredIterator struct {
+	Event *BridgeOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeOwnershipTransferred represents a OwnershipTransferred event raised by the Bridge contract.
+type BridgeOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Bridge *BridgeFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*BridgeOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeOwnershipTransferredIterator{contract: _Bridge.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Bridge *BridgeFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *BridgeOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeOwnershipTransferred)
+				if err := _Bridge.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseOwnershipTransferred is a log parse operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
+func (_Bridge *BridgeFilterer) ParseOwnershipTransferred(log types.Log) (*BridgeOwnershipTransferred, error) {
+	event := new(BridgeOwnershipTransferred)
+	if err := _Bridge.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgePausedIterator is returned from FilterPaused and is used to iterate over the raw logs and unpacked data for Paused events raised by the Bridge contract.
+type BridgePausedIterator struct {
+	Event *BridgePaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgePausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgePaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgePaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgePausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgePausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgePaused represents a Paused event raised by the Bridge contract.
+type BridgePaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterPaused is a free log retrieval operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Bridge *BridgeFilterer) FilterPaused(opts *bind.FilterOpts) (*BridgePausedIterator, error) {
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return &BridgePausedIterator{contract: _Bridge.contract, event: "Paused", logs: logs, sub: sub}, nil
+}
+
+// WatchPaused is a free log subscription operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Bridge *BridgeFilterer) WatchPaused(opts *bind.WatchOpts, sink chan<- *BridgePaused) (event.Subscription, error) {
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "Paused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgePaused)
+				if err := _Bridge.contract.UnpackLog(event, "Paused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParsePaused is a log parse operation binding the contract event 0x62e78cea01bee320cd4e420270b5ea74000d11b0c9f74754ebdbfc544b05a258.
+//
+// Solidity: event Paused(address account)
+func (_Bridge *BridgeFilterer) ParsePaused(log types.Log) (*BridgePaused, error) {
+	event := new(BridgePaused)
+	if err := _Bridge.contract.UnpackLog(event, "Paused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeUnpausedIterator is returned from FilterUnpaused and is used to iterate over the raw logs and unpacked data for Unpaused events raised by the Bridge contract.
+type BridgeUnpausedIterator struct {
+	Event *BridgeUnpaused // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeUnpausedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeUnpaused)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeUnpaused)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeUnpausedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeUnpausedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeUnpaused represents a Unpaused event raised by the Bridge contract.
+type BridgeUnpaused struct {
+	Account common.Address
+	Raw     types.Log // Blockchain specific contextual infos
+}
+
+// FilterUnpaused is a free log retrieval operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Bridge *BridgeFilterer) FilterUnpaused(opts *bind.FilterOpts) (*BridgeUnpausedIterator, error) {
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeUnpausedIterator{contract: _Bridge.contract, event: "Unpaused", logs: logs, sub: sub}, nil
+}
+
+// WatchUnpaused is a free log subscription operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Bridge *BridgeFilterer) WatchUnpaused(opts *bind.WatchOpts, sink chan<- *BridgeUnpaused) (event.Subscription, error) {
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "Unpaused")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeUnpaused)
+				if err := _Bridge.contract.UnpackLog(event, "Unpaused", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUnpaused is a log parse operation binding the contract event 0x5db9ee0a495bf2e6ff9c91a7834c1ba4fdd244a5e8aa4e537bd38aeae4b073aa.
+//
+// Solidity: event Unpaused(address account)
+func (_Bridge *BridgeFilterer) ParseUnpaused(log types.Log) (*BridgeUnpaused, error) {
+	event := new(BridgeUnpaused)
+	if err := _Bridge.contract.UnpackLog(event, "Unpaused", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// BridgeUpgradedIterator is returned from FilterUpgraded and is used to iterate over the raw logs and unpacked data for Upgraded events raised by the Bridge contract.
+type BridgeUpgradedIterator struct {
+	Event *BridgeUpgraded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *BridgeUpgradedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(BridgeUpgraded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(BridgeUpgraded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *BridgeUpgradedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *BridgeUpgradedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// BridgeUpgraded represents a Upgraded event raised by the Bridge contract.
+type BridgeUpgraded struct {
+	Implementation common.Address
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterUpgraded is a free log retrieval operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Bridge *BridgeFilterer) FilterUpgraded(opts *bind.FilterOpts, implementation []common.Address) (*BridgeUpgradedIterator, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Bridge.contract.FilterLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return &BridgeUpgradedIterator{contract: _Bridge.contract, event: "Upgraded", logs: logs, sub: sub}, nil
+}
+
+// WatchUpgraded is a free log subscription operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Bridge *BridgeFilterer) WatchUpgraded(opts *bind.WatchOpts, sink chan<- *BridgeUpgraded, implementation []common.Address) (event.Subscription, error) {
+
+	var implementationRule []interface{}
+	for _, implementationItem := range implementation {
+		implementationRule = append(implementationRule, implementationItem)
+	}
+
+	logs, sub, err := _Bridge.contract.WatchLogs(opts, "Upgraded", implementationRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(BridgeUpgraded)
+				if err := _Bridge.contract.UnpackLog(event, "Upgraded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseUpgraded is a log parse operation binding the contract event 0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b.
+//
+// Solidity: event Upgraded(address indexed implementation)
+func (_Bridge *BridgeFilterer) ParseUpgraded(log types.Log) (*BridgeUpgraded, error) {
+	event := new(BridgeUpgraded)
+	if err := _Bridge.contract.UnpackLog(event, "Upgraded", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/packages/taiko-client/cmd/flags/proposer.go
+++ b/packages/taiko-client/cmd/flags/proposer.go
@@ -22,6 +22,13 @@ var (
 		Category: proposerCategory,
 		EnvVars:  []string{"L2_SUGGESTED_FEE_RECIPIENT"},
 	}
+	BridgeAddress = &cli.StringFlag{
+		Name:     "bridge",
+		Usage:    "Bridge contract `address`",
+		Required: true,
+		Category: proposerCategory,
+		EnvVars:  []string{"BRIDGE"},
+	}
 )
 
 // Optional flags used by proposer.
@@ -159,6 +166,7 @@ var ProposerFlags = MergeFlags(CommonFlags, []cli.Flag{
 	TaikoTokenAddress,
 	L1ProposerPrivKey,
 	L2SuggestedFeeRecipient,
+	BridgeAddress,
 	ProposeInterval,
 	TxPoolLocals,
 	TxPoolLocalsOnly,

--- a/packages/taiko-client/pkg/rpc/client.go
+++ b/packages/taiko-client/pkg/rpc/client.go
@@ -51,6 +51,7 @@ type ClientConfig struct {
 	GuardianProverMajorityAddress common.Address
 	ProverSetAddress              common.Address
 	InboxAddress                  common.Address
+	BridgeAddress                 common.Address
 	L2EngineEndpoint              string
 	JwtSecret                     string
 	Timeout                       time.Duration

--- a/packages/taiko-client/proposer/config.go
+++ b/packages/taiko-client/proposer/config.go
@@ -112,6 +112,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			Timeout:           c.Duration(flags.RPCTimeout.Name),
 			ProverSetAddress:  common.HexToAddress(c.String(flags.ProverSetAddress.Name)),
 			InboxAddress:      common.HexToAddress(c.String(flags.InboxAddress.Name)),
+			BridgeAddress:     common.HexToAddress(c.String(flags.BridgeAddress.Name)),
 		},
 		L1ProposerPrivKey:          l1ProposerPrivKey,
 		L2SuggestedFeeRecipient:    common.HexToAddress(l2SuggestedFeeRecipient),

--- a/packages/taiko-client/proposer/proposer_test.go
+++ b/packages/taiko-client/proposer/proposer_test.go
@@ -1,7 +1,9 @@
 package proposer
 
 import (
+	"bytes"
 	"context"
+	"math"
 	"math/big"
 	"os"
 	"testing"
@@ -9,7 +11,6 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
@@ -75,6 +76,7 @@ func (s *ProposerTestSuite) SetupTest() {
 			TaikoL1Address:    common.HexToAddress(os.Getenv("TAIKO_L1")),
 			TaikoL2Address:    common.HexToAddress(os.Getenv("TAIKO_L2")),
 			TaikoTokenAddress: common.HexToAddress(os.Getenv("TAIKO_TOKEN")),
+			BridgeAddress:     common.HexToAddress(os.Getenv("BRIDGE_L1")),
 		},
 		L1ProposerPrivKey:          l1ProposerPrivKey,
 		L2SuggestedFeeRecipient:    common.HexToAddress(os.Getenv("L2_SUGGESTED_FEE_RECIPIENT")),
@@ -470,4 +472,135 @@ func (s *ProposerTestSuite) TestIsProfitable() {
 			s.Equal(test.expectedResult, profitable)
 		})
 	}
+}
+
+func (s *ProposerTestSuite) TestBridgeMessageMonitoring() {
+	// ===== Setup Phase =====
+	// Create a test transaction that simulates a Bridge sendMessage call
+	bridgeAddr := s.p.Config.ClientConfig.BridgeAddress
+	s.NotEqual(bridgeAddr, common.Address{}, "Bridge address should not be zero")
+	log.Info("Using Bridge address for test", "address", bridgeAddr.Hex())
+
+	// Start the proposer first to ensure subscription is active
+	s.Nil(s.p.Start())
+
+	// ===== Test Case 1: Valid Bridge Message Transaction =====
+	// Now create and send the Bridge message transaction
+	selectorBytes := common.FromHex("1bdb0037") // Remove 0x prefix to avoid double prefix
+	testData := append(selectorBytes, testutils.RandomBytes(100)...)
+
+	testNonce, err := s.p.rpc.L1.NonceAt(context.Background(), s.TestAddr, nil)
+	s.Nil(err)
+
+	// Get current base fee
+	header, err := s.p.rpc.L1.HeaderByNumber(context.Background(), nil)
+	s.Nil(err)
+	baseFee := header.BaseFee
+
+	// Get chain ID
+	chainID := s.p.rpc.L1.ChainID
+
+	// Create a signed transaction with very low gas price to keep it pending
+	gasFeeCap := new(big.Int).Add(baseFee, big.NewInt(1)) // Set max fee per gas just slightly above base fee
+	gasTipCap := big.NewInt(1)                            // Set priority fee (tip) very low
+
+	signer := types.LatestSignerForChainID(chainID)
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     testNonce,
+		To:        &bridgeAddr,
+		Value:     common.Big1,
+		Gas:       100000,
+		GasFeeCap: gasFeeCap,
+		GasTipCap: gasTipCap,
+		Data:      testData,
+	})
+
+	signedTx, err := types.SignTx(tx, signer, s.TestAddrPrivKey)
+	s.Nil(err)
+
+	err = s.p.rpc.L1.SendTransaction(context.Background(), signedTx)
+	s.Nil(err)
+
+	log.Info(
+		"Sent Bridge message transaction",
+		"hash", signedTx.Hash().Hex(),
+		"from", s.TestAddr.Hex(),
+		"to", bridgeAddr.Hex(),
+		"nonce", testNonce,
+		"value", signedTx.Value(),
+		"gasFeeCap", gasFeeCap,
+		"gasTipCap", gasTipCap,
+	)
+
+	time.Sleep(2 * time.Second)
+
+	// Verify the transaction was detected and stored
+	s.p.bridgeMsgMu.RLock()
+	detected := s.p.pendingBridgeMessages[signedTx.Hash()]
+	s.p.bridgeMsgMu.RUnlock()
+
+	s.NotNil(detected, "Bridge message transaction should be detected")
+	s.Equal(signedTx.Hash(), detected.Hash(), "Detected transaction hash should match sent transaction")
+	s.Equal(bridgeAddr, *detected.To(), "Detected transaction should be to Bridge contract")
+	s.True(bytes.HasPrefix(detected.Data(), selectorBytes), "Transaction should have sendMessage selector")
+
+	// ===== Test Case 2: Non-Bridge Transaction =====
+	// Test that non-Bridge transactions are not detected
+	randomAddr := common.BytesToAddress(testutils.RandomBytes(20))
+	nonBridgeTx, err := testutils.AssembleAndSendTestTx(
+		s.p.rpc.L1,
+		s.TestAddrPrivKey,
+		testNonce+1,
+		&randomAddr,
+		common.Big1,
+		testutils.RandomBytes(100),
+	)
+	s.Nil(err)
+	s.NotNil(nonBridgeTx, "Non-bridge transaction should not be nil")
+
+	time.Sleep(2 * time.Second)
+
+	// Verify the non-Bridge transaction was not detected
+	s.p.bridgeMsgMu.RLock()
+	notDetected := s.p.pendingBridgeMessages[nonBridgeTx.Hash()]
+	s.p.bridgeMsgMu.RUnlock()
+
+	s.Nil(notDetected, "Non-Bridge transaction should not be detected")
+
+	// ===== Test Case 3: Invalid Bridge Transaction =====
+	// Test that Bridge transactions without sendMessage selector are not detected
+	invalidSelectorTx, err := testutils.AssembleAndSendTestTx(
+		s.p.rpc.L1,
+		s.TestAddrPrivKey,
+		testNonce+2,
+		&bridgeAddr,
+		common.Big1,
+		testutils.RandomBytes(100),
+	)
+	s.Nil(err)
+	s.NotNil(invalidSelectorTx, "Invalid selector transaction should not be nil")
+
+	time.Sleep(2 * time.Second)
+
+	// Verify the Bridge transaction without sendMessage selector was not detected
+	s.p.bridgeMsgMu.RLock()
+	notDetectedInvalid := s.p.pendingBridgeMessages[invalidSelectorTx.Hash()]
+	s.p.bridgeMsgMu.RUnlock()
+
+	s.Nil(notDetectedInvalid, "Bridge transaction without sendMessage selector should not be detected")
+
+	// ===== Test Case 4: Cleanup After Proposal =====
+	// Test that detected transactions are cleared after being proposed
+	s.Nil(s.p.ProposeOp(context.Background()))
+
+	s.p.bridgeMsgMu.RLock()
+	remainingMsgs := len(s.p.pendingBridgeMessages)
+	s.p.bridgeMsgMu.RUnlock()
+
+	s.Equal(0, remainingMsgs, "Pending messages should be cleared after proposing")
+
+	// ===== Cleanup =====
+	s.cancel()
+	s.NotPanics(func() { s.p.Close(s.p.ctx) })
 }


### PR DESCRIPTION
## Context

This PR updates the proposer service to listen for particular transactions: `sendMessage` calls from `Bridge.sol` on the L1 RPC. This is the **first step** toward implementing same-slot fast L1 to L2 bridging (https://github.com/NethermindEth/Surge/issues/67).

An overview of the new fast bridging design can be found [here](https://ethresear.ch/t/same-slot-l1-l2-message-passing/21186).

Since this new design consists of multiple parts, I am updating the codebase through small, digestible PRs.

## Key changes

1. **Bridge flag**  
   Added a `--bridge` flag to the proposer to pass the bridge contract address at launch. The implementation follows the style and structure of existing flags for consistency.

2. **Asynchronous bridge transaction monitoring**  
   Introduced an asynchronous mechanism in the proposer's main logic to:
   - Subscribe to the L1 client for new pending transactions.
   - Detect transactions that specifically call the `sendMessage` function on the Bridge contract.

3. **New Go binding `Bridge.go`**
    I generated a new Go binding under the `taiko-client` package to avoid hardcoding the hex selector value for the `sendMessage` function. Instead, this binding relies on the clean and robust API provided by the newly generated `Bridge.go` file.
    - Generated this Go code using [abigen](https://geth.ethereum.org/docs/tools/abigen) from the ABI file produced by compiling `Bridge.sol` with [solc](https://docs.soliditylang.org/en/latest/installing-solidity.html).
    - The generated `Bridge.go` file is identical to the existing `Bridge.go` files in the `relayer` and `eventindexer` packages. Given that these packages (`relayer`, `eventindexer`, and now `taiko-client`) are intentionally isolated with distinct setup instructions and code designs, it makes sense for each package to maintain its own separate bindings despite duplication. Although all packages reside within the single `taiko-mono` repository, maintaining separate bindings helps prevent unnecessary cross-package dependencies and explicitly clarifies ownership. Therefore, I have chosen to adhere to this existing design principle rather than reusing the bindings from `relayer` or `eventindexer` in the `taiko-client` package.

## Caveat to note

Although the code listens and detects the transactions, the handling logic in the `ProposeOp` function is not yet fully implemented.  The actual processing will be introduced in the next PR, as noted in the TODO comment.

## Verification of correctness

I spent considerable effort setting up a local environment to verify that the new changes work as expected. **Note:** this section is primarily for documentation and knowledge sharing and for my future reference. It's not necessary for reviewing the PR.

### Setup overview

I am running all L1 and L2 services on a Linode instance. 

For L1 node, I am using [Eth Docker](https://ethdocker.com/Usage/QuickStart/). Alternatively, one could use [Sedge](https://docs.sedge.nethermind.io/docs/quickstart/complete-guide), but I am using the former simply because it offers nice, easy-to-understand Grafana dashboards out of the box.

For L2, I need the driver to be up and running because proposer can't run without it. For that, I used Docker Compose setup from `simple-surge-node`. [Guide](https://docs.surge.wtf/docs/guides/surge-on-hoodi/run-l2).

For the proposer itself, I've set up VSCode debugger. Alternatively, one can build the `taiko-client` binary (`make build`)and ran it manually with the following flags (which what I used to verify the changes):

```bash
bin/taiko-client proposer \
--l1.ws ws://<linode_ip>:8546 \
--l2.http http://localhost:8547 \
--l2.auth http://localhost:8552 \
--taikoL1 0x4bBeF0eFDe3692b9B31BaCDA30f933D223f18A82 \
--taikoL2 0x7633750000000000000000000000000000010001 \
--jwtSecret /tmp/jwt/jwtsecret \
--l1.proposerPrivKey <my_own_private_key> \
--l2.suggestedFeeRecipient 0xD51a7E12997f6f1D04AcCC2b4053307a62b373cb \
--bridge 0x4d469D3c2D17252A688da5613571A43a109F4F89
```

Key flags to pay attention to: `--l1.ws`, `--l2.http`, `--l2.auth`, and `--bridge`. Others are proposer requirements and mostly defaults from simple-surge-node.

### Actual verification

To trigger a `sendMessage` transaction locally, I wrote a simple Solidity script:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.24;

import "forge-std/src/Script.sol";
import "src/shared/bridge/IBridge.sol";

contract SendTestMessage is Script {
    function run() external {
        vm.startBroadcast();

        address bridgeAddress = 0x4d469D3c2D17252A688da5613571A43a109F4F89;
        address senderReceiver = 0xAbc016AB4a83bC9ac96caC562659a528591209Cd;
        uint64 sourceChainId = 560048; // Hoodi chain ID
        uint64 destChainId = 763375;   // L2 Surge chain ID

        IBridge.Message memory message = IBridge.Message({
            id: 0, // Will be set by the bridge
            from: senderReceiver,
            srcChainId: sourceChainId,
            srcOwner: senderReceiver,
            destChainId: destChainId,
            destOwner: senderReceiver,
            to: senderReceiver,
            value: 0,
            fee: 0,
            gasLimit: 1_000_000,
            data: abi.encode("Hello World")
        });

        IBridge(bridgeAddress).sendMessage(message);

        vm.stopBroadcast();
    }
}
```

Note that the `bridgeAddress` matches the one passed when running the proposer binary above.

I executed the script using: `forge script script/layer1/SendTestMessage.s.sol \
    --rpc-url http://<linode_ip_address>:8545 \
    --private-key <my_own_private_key> \
    --broadcast`. 

And the following output was produced:

```bash
[⠊] Compiling...
No files changed, compilation skipped
Script ran successfully.

## Setting up 1 EVM.

==========================

Chain 560048

Estimated gas price: 1.931896416 gwei

Estimated total gas used for script: 137846

Estimated amount required: 0.000266304193359936 ETH

==========================

##### 560048
✅  [Success] Hash: 0x6ed781ac25cd01c52222fefc9b5b18db7f080922e61faaa47f05133b19e92f0c
Block: 288585
Paid: 0.000111019706555744 ETH (99799 gas * 1.112433056 gwei)

✅ Sequence #1 on 560048 | Total Paid: 0.000111019706555744 ETH (99799 gas * avg 1.112433056 gwei)
                                                                                                                                                                                                                             

==========================

ONCHAIN EXECUTION COMPLETE & SUCCESSFUL.

Transactions saved to: /home/nurbakyt/code/surge-taiko-mono/packages/protocol/broadcast/SendTestMessage.s.sol/560048/run-latest.json

Sensitive values saved to: /home/nurbakyt/code/surge-taiko-mono/packages/protocol/cache/SendTestMessage.s.sol/560048/run-latest.json
```

And if we actually check proposer logs, we can see that it detected the transaction (only relevant lines are shown):

```bash
INFO [04-29|13:36:30.710] Successfully connected to L1 RPC         currentBlock=288,582
INFO [04-29|13:36:51.062] New Bridge sendMessage transaction detected in mempool hash=6ed781..e92f0c
INFO [04-29|13:38:27.717] Pending Bridge sendMessage transactions  count=1
```

The transaction was detected and logged exactly as expected.

## Testing

The recent changes to the proposer functionality have been covered by a test located in `proposer_test.go`. Note that integration tests currently fail in the `surge-taiko-mono` repository due to an ambiguous issue I was unable to identify. As a workaround, I used the upstream `taiko-mono` repository to implement and successfully run the test. Once `surge-taiko-mono` is rebased with the upstream `taiko-mono`, I plan to rerun and revalidate the test to ensure it continues to work as expected.

For context, the following was the steps I run tests on upstream repo:

```bash
# Clone the upstream taiko-mono repo
git clone https://github.com/taikoxyz/taiko-mono old-fork-taiko-mono
cd old-fork-taiko-mono
git checkout protocol-v1.12.1-devnet
cd packages/protocol && pnpm install

# Switch back to local taiko-mono repo
export OLD_FORK_TAIKO_MONO=/home/nurbakyt/code/old-fork-taiko-mono
cd packages/taiko-client
PACKAGE=proposer make test
```

And my tests succeeded:

```
--- PASS: TestProposerTestSuite (16.41s)
    --- PASS: TestProposerTestSuite/TestBridgeMessageMonitoring (16.41s)
        --- PASS: TestProposerTestSuite/TestBridgeMessageMonitoring/Valid_Bridge_Message_Transaction (2.00s)
        --- PASS: TestProposerTestSuite/TestBridgeMessageMonitoring/Non-Bridge_Transaction (2.00s)
        --- PASS: TestProposerTestSuite/TestBridgeMessageMonitoring/Invalid_Bridge_Transaction (2.00s)
        --- PASS: TestProposerTestSuite/TestBridgeMessageMonitoring/Cleanup_After_Proposal (3.19s)
PASS
coverage: 51.3% of statements
ok      github.com/taikoxyz/taiko-mono/packages/taiko-client/proposer   16.485s coverage: 51.3% of statements
```