### PR TITLE
Cherry-pick Surge-specific `taiko-client` updates from `main` to `main-pacaya` (Part 1)

### DIFF
--- a/packages/taiko-client/bindings/encoding/custom_error.go
+++ b/packages/taiko-client/bindings/encoding/custom_error.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"encoding/hex"
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -62,7 +63,7 @@ func TryParsingCustomError(originalError error) error {
 		return nil
 	}
 
-	errData := getErrorData(originalError)
+	errData := standardizeErrorData(getErrorData(originalError))
 
 	// if errData is unparsable and returns 0x, we should not match any errors.
 	if errData == "0x" {
@@ -102,4 +103,16 @@ func getErrorData(err error) string {
 	}
 
 	return err.Error()
+}
+
+// standardizeErrorData standardizes the error data to a hex string
+// considering Nethermind's error data format
+func standardizeErrorData(errData string) string {
+	errData = strings.TrimPrefix(errData, "Reverted ")
+
+	if !strings.HasPrefix(errData, "0x") {
+		errData = "0x" + hex.EncodeToString([]byte(errData))
+	}
+
+	return errData
 }

--- a/packages/taiko-client/cmd/flags/common.go
+++ b/packages/taiko-client/cmd/flags/common.go
@@ -85,7 +85,7 @@ var (
 	TaikoTokenAddress = &cli.StringFlag{
 		Name:     "taikoToken",
 		Usage:    "TaikoToken contract `address`",
-		Required: true,
+		Value:    rpc.ZeroAddress.Hex(),
 		Category: commonCategory,
 		EnvVars:  []string{"TAIKO_TOKEN"},
 	}

--- a/packages/taiko-client/pkg/rpc/utils.go
+++ b/packages/taiko-client/pkg/rpc/utils.go
@@ -49,57 +49,73 @@ func CheckProverBalance(
 	ctxWithTimeout, cancel := CtxWithTimeoutOrDefault(ctx, defaultTimeout)
 	defer cancel()
 
-	// Check allowance on taiko token contract
-	allowance, err := rpc.PacayaClients.TaikoToken.Allowance(&bind.CallOpts{Context: ctxWithTimeout}, prover, address)
-	if err != nil {
-		return false, err
-	}
+	if rpc.PacayaClients.TaikoToken != nil {
+		// Check allowance on taiko token contract
+		allowance, err := rpc.PacayaClients.TaikoToken.Allowance(&bind.CallOpts{Context: ctxWithTimeout}, prover, address)
+		if err != nil {
+			return false, err
+		}
 
-	log.Info(
-		"Prover allowance for the contract",
-		"allowance", utils.WeiToEther(allowance),
-		"address", prover.Hex(),
-		"bond", utils.WeiToEther(bond),
-	)
-
-	// Check prover's taiko token bondBalance
-	bondBalance, err := rpc.PacayaClients.TaikoInbox.BondBalanceOf(&bind.CallOpts{Context: ctxWithTimeout}, prover)
-	if err != nil {
-		return false, err
-	}
-
-	// Check prover's taiko token tokenBalance
-	tokenBalance, err := rpc.PacayaClients.TaikoToken.BalanceOf(&bind.CallOpts{Context: ctxWithTimeout}, prover)
-	if err != nil {
-		return false, err
-	}
-
-	log.Info(
-		"Prover's wallet taiko token balance",
-		"bondBalance", utils.WeiToEther(bondBalance),
-		"tokenBalance", utils.WeiToEther(tokenBalance),
-		"address", prover.Hex(),
-		"bond", utils.WeiToEther(bond),
-	)
-
-	if bond.Cmp(allowance) > 0 && bond.Cmp(bondBalance) > 0 {
 		log.Info(
-			"Assigned prover does not have required on-chain token allowance",
+			"Prover allowance for the contract",
 			"allowance", utils.WeiToEther(allowance),
-			"bondBalance", utils.WeiToEther(bondBalance),
+			"address", prover.Hex(),
 			"bond", utils.WeiToEther(bond),
 		)
-		return false, nil
-	}
 
-	if bond.Cmp(bondBalance) > 0 && bond.Cmp(tokenBalance) > 0 {
+		// Check prover's taiko token bondBalance
+		bondBalance, err := rpc.PacayaClients.TaikoInbox.BondBalanceOf(&bind.CallOpts{Context: ctxWithTimeout}, prover)
+		if err != nil {
+			return false, err
+		}
+
+		// Check prover's taiko token tokenBalance
+		tokenBalance, err := rpc.PacayaClients.TaikoToken.BalanceOf(&bind.CallOpts{Context: ctxWithTimeout}, prover)
+		if err != nil {
+			return false, err
+		}
+
 		log.Info(
-			"Assigned prover does not have required on-chain token balance",
+			"Prover's wallet taiko token balance",
 			"bondBalance", utils.WeiToEther(bondBalance),
 			"tokenBalance", utils.WeiToEther(tokenBalance),
+			"address", prover.Hex(),
 			"bond", utils.WeiToEther(bond),
 		)
-		return false, nil
+
+		if bond.Cmp(allowance) > 0 && bond.Cmp(bondBalance) > 0 {
+			log.Info(
+				"Assigned prover does not have required on-chain token allowance",
+				"allowance", utils.WeiToEther(allowance),
+				"bondBalance", utils.WeiToEther(bondBalance),
+				"bond", utils.WeiToEther(bond),
+			)
+			return false, nil
+		}
+
+		if bond.Cmp(bondBalance) > 0 && bond.Cmp(tokenBalance) > 0 {
+			log.Info(
+				"Assigned prover does not have required on-chain token balance",
+				"bondBalance", utils.WeiToEther(bondBalance),
+				"tokenBalance", utils.WeiToEther(tokenBalance),
+				"bond", utils.WeiToEther(bond),
+			)
+			return false, nil
+		}
+	} else {
+		bondBalance, err := rpc.PacayaClients.TaikoInbox.BondBalanceOf(&bind.CallOpts{Context: ctxWithTimeout}, prover)
+		if err != nil {
+			return false, err
+		}
+
+		if bond.Cmp(bondBalance) > 0 {
+			log.Info(
+				"Assigned prover does not have required on-chain Eth balance",
+				"bondBalance", utils.WeiToEther(bondBalance),
+				"bond", utils.WeiToEther(bond),
+			)
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/packages/taiko-client/prover/init.go
+++ b/packages/taiko-client/prover/init.go
@@ -31,6 +31,12 @@ func (p *Prover) setApprovalAmount(ctx context.Context, contract common.Address)
 		return nil
 	}
 
+	// Skip setting allowance if taiko token contract is not found.
+	if p.rpc.PacayaClients.TaikoToken == nil {
+		log.Info("Skipping setting allowance, taiko token contract not found")
+		return nil
+	}
+
 	// Check the existing allowance for the contract.
 	allowance, err := p.rpc.PacayaClients.TaikoToken.Allowance(
 		&bind.CallOpts{Context: ctx},

--- a/packages/taiko-client/prover/proof_submitter/transaction/sender.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/sender.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/ethereum-optimism/optimism/op-service/txmgr"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -90,8 +92,18 @@ func (s *Sender) Send(
 
 	// Send the transaction.
 	txMgr, isPrivate := s.txmgrSelector.Select()
-	receipt, err := txMgr.Send(ctx, *txCandidate)
-	if err != nil {
+	var receipt *types.Receipt
+	if err = backoff.Retry(
+		func() error {
+			var err error
+			receipt, err = txMgr.Send(ctx, *txCandidate)
+			return err
+		},
+		backoff.WithContext(
+			backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5),
+			ctx,
+		),
+	); err != nil {
 		if isPrivate {
 			s.txmgrSelector.RecordPrivateTxMgrFailed()
 		}


### PR DESCRIPTION
This PR selectively cherry-picks Surge-specific commits related to `taiko-client` from the current `main` branch onto a fresh `main-pacaya` branch. These changes are part of a rebasing Surge-specific logic on top of `main-pacaya` branch that is taiko-alethia-protocol version 2.3.0. 

**Follow-up PRs:**
Further cherry-picked commits will be handled in subsequent PRs (Parts 2+).
