### PR TITLE
feat(protocol): allow custom base fee during batch proposals

### DIFF
--- a/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/ITaikoInbox.sol
@@ -53,6 +53,7 @@ interface ITaikoInbox {
         address proposer;
         address coinbase;
         bytes32 parentMetaHash;
+        uint96 baseFee; // Custom L2 base fee set by the proposer
         uint64 anchorBlockId;
         uint64 lastBlockTimestamp;
         bool revertIfNotFirstProposal;
@@ -75,6 +76,7 @@ interface ITaikoInbox {
         uint32 blobByteOffset;
         uint32 blobByteSize;
         uint32 gasLimit;
+        uint96 baseFee; // Custom L2 base fee set by the proposer
         uint64 lastBlockId;
         uint64 lastBlockTimestamp;
         // Data for the L2 anchor transaction, shared by all blocks in the batch

--- a/packages/protocol/contracts/layer1/based/TaikoInbox.sol
+++ b/packages/protocol/contracts/layer1/based/TaikoInbox.sol
@@ -176,6 +176,7 @@ abstract contract TaikoInbox is EssentialContract, ITaikoInbox, IProposeBatch, I
                 blobByteOffset: params.blobParams.byteOffset,
                 blobByteSize: params.blobParams.byteSize,
                 gasLimit: config.blockMaxGasLimit,
+                baseFee: params.baseFee,
                 lastBlockId: 0, // to be initialised later
                 lastBlockTimestamp: lastBlockTimestamp,
                 //

--- a/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
+++ b/packages/protocol/contracts/layer2/based/TaikoAnchor.sol
@@ -166,7 +166,8 @@ contract TaikoAnchor is EssentialContract, IBlockHashProvider, TaikoAnchorDeprec
 
         uint256 parentId = block.number - 1;
         _verifyAndUpdatePublicInputHash(parentId);
-        _verifyBaseFeeAndUpdateGasExcess(_parentGasUsed, _baseFeeConfig);
+        // Surge: Base fee is no longer enforced in the anchor transaction
+        // _verifyBaseFeeAndUpdateGasExcess(_parentGasUsed, _baseFeeConfig);
         _syncChainData(_anchorBlockId, _anchorStateRoot);
         _updateParentHashAndTimestamp(parentId);
 

--- a/packages/protocol/deployments/test_inbox_measure_gas_used.txt
+++ b/packages/protocol/deployments/test_inbox_measure_gas_used.txt
@@ -1,5 +1,5 @@
 See `test_inbox_measure_gas_used` in InboxTest_ProposeAndProve.t.sol
 
-Gas per proposeBatches: 651642
-Gas per proveBatches: 104868
-Total: 756511
+Gas per proposeBatches: 654904
+Gas per proveBatches: 105267
+Total: 760171

--- a/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
+++ b/packages/protocol/test/layer1/preconf/mocks/MockTaikoInbox.sol
@@ -31,6 +31,7 @@ contract MockTaikoInbox is EssentialContract {
             extraData: bytes32(0),
             coinbase: params.coinbase == address(0) ? params.proposer : params.coinbase,
             gasLimit: 0, // Mock value
+            baseFee: 0,
             lastBlockId: 0,
             lastBlockTimestamp: 0,
             proposedIn: uint64(block.number),

--- a/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
+++ b/packages/protocol/test/layer1/preconf/router/PreconfRouter.t.sol
@@ -43,6 +43,7 @@ contract PreconfRouterTest is PreconfRouterTestBase {
             proposer: Carol,
             coinbase: address(0),
             parentMetaHash: bytes32(0),
+            baseFee: 0,
             anchorBlockId: 0,
             lastBlockTimestamp: uint64(block.timestamp),
             revertIfNotFirstProposal: false,
@@ -129,6 +130,7 @@ contract PreconfRouterTest is PreconfRouterTestBase {
             proposer: Bob, // Set different proposer than sender (Carol)
             coinbase: address(0),
             parentMetaHash: bytes32(0),
+            baseFee: 0,
             anchorBlockId: 0,
             lastBlockTimestamp: uint64(block.timestamp),
             revertIfNotFirstProposal: false,

--- a/packages/protocol/test/layer2/TaikoAnchor.t.sol
+++ b/packages/protocol/test/layer2/TaikoAnchor.t.sol
@@ -107,53 +107,54 @@ contract TestTaikoAnchor is Layer2Test {
         assertTrue(basefee_ != 0, "basefee is 0");
     }
 
+    // Surge: Base fee is no longer enforced in the anchor transaction
     /// forge-config: default.fuzz_runs = 2000
     /// forge-config: default.fuzz_runs_show_logs = true
-    function test_fuzz_anchorV3(
-        uint32 _parentGasUsed,
-        uint32 _gasIssuancePerSecond,
-        uint64 _minGasExcess,
-        uint32 _maxGasIssuancePerBlock,
-        uint8 _adjustmentQuotient,
-        uint8 _sharingPctg
-    )
-        external
-        onTaiko
-    {
-        if (_parentGasUsed == 0) _parentGasUsed = 1;
-        if (_gasIssuancePerSecond == 0) _gasIssuancePerSecond = 1;
-        if (_gasIssuancePerSecond == type(uint32).max) _gasIssuancePerSecond -= 1;
-        if (_adjustmentQuotient == 0) _adjustmentQuotient = 1;
+    // function test_fuzz_anchorV3(
+    //     uint32 _parentGasUsed,
+    //     uint32 _gasIssuancePerSecond,
+    //     uint64 _minGasExcess,
+    //     uint32 _maxGasIssuancePerBlock,
+    //     uint8 _adjustmentQuotient,
+    //     uint8 _sharingPctg
+    // )
+    //     external
+    //     onTaiko
+    // {
+    //     if (_parentGasUsed == 0) _parentGasUsed = 1;
+    //     if (_gasIssuancePerSecond == 0) _gasIssuancePerSecond = 1;
+    //     if (_gasIssuancePerSecond == type(uint32).max) _gasIssuancePerSecond -= 1;
+    //     if (_adjustmentQuotient == 0) _adjustmentQuotient = 1;
 
-        LibSharedData.BaseFeeConfig memory baseFeeConfig = LibSharedData.BaseFeeConfig({
-            adjustmentQuotient: _adjustmentQuotient,
-            sharingPctg: uint8(_sharingPctg % 100),
-            gasIssuancePerSecond: _gasIssuancePerSecond,
-            minGasExcess: _minGasExcess,
-            maxGasIssuancePerBlock: _maxGasIssuancePerBlock
-        });
+    //     LibSharedData.BaseFeeConfig memory baseFeeConfig = LibSharedData.BaseFeeConfig({
+    //         adjustmentQuotient: _adjustmentQuotient,
+    //         sharingPctg: uint8(_sharingPctg % 100),
+    //         gasIssuancePerSecond: _gasIssuancePerSecond,
+    //         minGasExcess: _minGasExcess,
+    //         maxGasIssuancePerBlock: _maxGasIssuancePerBlock
+    //     });
 
-        bytes32 anchorStateRoot = bytes32(uint256(1));
-        vm.prank(anchor.GOLDEN_TOUCH_ADDRESS());
-        anchor.anchorV3(
-            ++anchorBlockId, anchorStateRoot, _parentGasUsed, baseFeeConfig, new bytes32[](0)
-        );
+    //     bytes32 anchorStateRoot = bytes32(uint256(1));
+    //     vm.prank(anchor.GOLDEN_TOUCH_ADDRESS());
+    //     anchor.anchorV3(
+    //         ++anchorBlockId, anchorStateRoot, _parentGasUsed, baseFeeConfig, new bytes32[](0)
+    //     );
 
-        (uint256 basefee, uint64 newGasTarget,) =
-            anchor.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
+    //     (uint256 basefee, uint64 newGasTarget,) =
+    //         anchor.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
 
-        assertTrue(basefee != 0, "basefee is 0");
-        assertEq(newGasTarget, anchor.parentGasTarget());
+    //     assertTrue(basefee != 0, "basefee is 0");
+    //     assertEq(newGasTarget, anchor.parentGasTarget());
 
-        // change the gas issuance to change the gas target
-        baseFeeConfig.gasIssuancePerSecond += 1;
+    //     // change the gas issuance to change the gas target
+    //     baseFeeConfig.gasIssuancePerSecond += 1;
 
-        (basefee, newGasTarget,) =
-            anchor.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
+    //     (basefee, newGasTarget,) =
+    //         anchor.getBasefeeV2(_parentGasUsed, uint64(block.timestamp), baseFeeConfig);
 
-        assertTrue(basefee != 0, "basefee is 0");
-        assertTrue(newGasTarget != anchor.parentGasTarget());
-    }
+    //     assertTrue(basefee != 0, "basefee is 0");
+    //     assertTrue(newGasTarget != anchor.parentGasTarget());
+    // }
 
     function _anchorV3(uint32 parentGasUsed) private {
         bytes32 anchorStateRoot = randBytes32();


### PR DESCRIPTION
- The proposer can assign a custom base fee to a batch
- The anchor transaction no longer enforces a dynamically computed base fee