### PR TITLE
feat(protocol): add proposer wrapper

### DIFF
--- a/packages/protocol/contracts/layer1/surge/common/SurgeProposerWrapper.sol
+++ b/packages/protocol/contracts/layer1/surge/common/SurgeProposerWrapper.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "src/layer1/based/IProposeBatch.sol";
+import "src/layer1/based/ITaikoInbox.sol";
+
+/// @title SurgeProposerWrapper
+/// @dev Allows for managing multiple proposer and prover keys while keeping the same
+/// sender in the inbox.
+/// @custom:security-contact security@nethermind.io
+contract SurgeProposerWrapper {
+    address internal immutable taikoWrapper;
+    address internal immutable taikoInbox;
+
+    address internal admin;
+    mapping(address caller => bool isAuthorized) internal authorizedCallers;
+
+    error NotAdmin();
+    error NotAuthorized();
+
+    modifier onlyAdmin() {
+        if (msg.sender != admin) {
+            revert NotAdmin();
+        }
+        _;
+    }
+
+    modifier onlyAuthorized() {
+        if (!authorizedCallers[msg.sender]) {
+            revert NotAuthorized();
+        }
+        _;
+    }
+
+    constructor(address _admin, address _taikoWrapper, address _taikoInbox) {
+        admin = _admin;
+        taikoWrapper = _taikoWrapper;
+        taikoInbox = _taikoInbox;
+    }
+
+    // Admin functions
+    // --------------------------------------------------------------------------------------------
+
+    function authorizeCaller(address caller) external onlyAdmin {
+        authorizedCallers[caller] = true;
+    }
+
+    function deauthorizeCaller(address caller) external onlyAdmin {
+        authorizedCallers[caller] = false;
+    }
+
+    function setAdmin(address newAdmin) external onlyAdmin {
+        admin = newAdmin;
+    }
+
+    // Authorized calls
+    // --------------------------------------------------------------------------------------------
+
+    function proposeBatch(
+        bytes calldata _params,
+        bytes calldata _txList
+    )
+        external
+        onlyAuthorized
+        returns (ITaikoInbox.BatchInfo memory, ITaikoInbox.BatchMetadata memory)
+    {
+        return IProposeBatch(taikoWrapper).proposeBatch(_params, _txList);
+    }
+
+    function proveBatches(bytes calldata _params, bytes calldata _proof) external onlyAuthorized {
+        ITaikoInbox(taikoInbox).proveBatches(_params, _proof);
+    }
+
+    function depositBond(uint256 _amount) external payable onlyAuthorized {
+        ITaikoInbox(taikoInbox).depositBond{ value: _amount }(_amount);
+    }
+
+    function withdrawBond(uint256 _amount) external onlyAuthorized {
+        ITaikoInbox(taikoInbox).withdrawBond(_amount);
+    }
+}

--- a/packages/protocol/script/layer1/surge/DeployProposerWrapper.s.sol
+++ b/packages/protocol/script/layer1/surge/DeployProposerWrapper.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+// Foundry
+import "forge-std/src/Script.sol";
+
+// Local imports
+import "src/layer1/surge/common/SurgeProposerWrapper.sol";
+
+contract DeployProposerWrapper is Script {
+    // Execution configuration
+    // ---------------------------------------------------------------------------------------------
+    uint256 internal immutable privateKey = vm.envUint("PRIVATE_KEY");
+
+    // Proposer wrapper configuration
+    // ---------------------------------------------------------------------------------------------
+    address internal taikoWrapper = vm.envAddress("TAIKO_WRAPPER");
+    address internal taikoInbox = vm.envAddress("TAIKO_INBOX");
+    address internal admin = vm.envAddress("ADMIN");
+
+    modifier broadcast() {
+        require(privateKey != 0, "invalid private key");
+        vm.startBroadcast(privateKey);
+        _;
+        vm.stopBroadcast();
+    }
+
+    function run() external broadcast {
+        require(taikoWrapper != address(0), "config: TAIKO_WRAPPER");
+        require(taikoInbox != address(0), "config: TAIKO_INBOX");
+        require(admin != address(0), "config: ADMIN");
+
+        SurgeProposerWrapper proposerWrapper =
+            new SurgeProposerWrapper(admin, taikoWrapper, taikoInbox);
+        console2.log("Surge proposer wrapper deployed at: ", address(proposerWrapper));
+    }
+}

--- a/packages/protocol/script/layer1/surge/deploy_proposer_wrapper.sh
+++ b/packages/protocol/script/layer1/surge/deploy_proposer_wrapper.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# This script deploys the Surge Proposer Wrapper on L1
+set -e
+
+# Deployer private key
+export PRIVATE_KEY=${PRIVATE_KEY:-"0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"}
+
+# Network configuration
+export FORK_URL=${FORK_URL:-"http://localhost:8545"}
+
+# Proposer wrapper configuration
+export TAIKO_WRAPPER=${TAIKO_WRAPPER:-"0x0000000000000000000000000000000000000001"}
+export TAIKO_INBOX=${TAIKO_INBOX:-"0x0000000000000000000000000000000000000001"}
+export ADMIN=${ADMIN:-"0x1237810000000000000000000000000000000001"}
+
+# Deploy Surge Proposer Wrapper
+export FOUNDRY_PROFILE=${FOUNDRY_PROFILE:-"layer1"}
+
+# Broadcast transactions
+export BROADCAST=${BROADCAST:-false}
+
+# Parameterize broadcasting
+export BROADCAST_ARG=""
+if [ "$BROADCAST" = "true" ]; then
+    BROADCAST_ARG="--broadcast"
+fi
+
+# Parameterize log level
+export LOG_LEVEL=${LOG_LEVEL:-"-vvvv"}
+
+# Parameterize block gas limit
+export BLOCK_GAS_LIMIT=${BLOCK_GAS_LIMIT:-200000000}
+
+forge script ./script/layer1/surge/DeployProposerWrapper.s.sol:DeployProposerWrapper \
+    --fork-url $FORK_URL \
+    $BROADCAST_ARG \
+    --ffi \
+    $LOG_LEVEL \
+    --private-key $PRIVATE_KEY \
+    --block-gas-limit $BLOCK_GAS_LIMIT 


### PR DESCRIPTION
### What does this PR do?
---

We are currently facing nonce-management issues due to the proposer and prover keys being the same. This PR adds a `SurgeProposerWrapper` that will now serve as the intermediate sender of the proposal and proving calls.

### What modifications are required in the deployment process?
---

- For each "proposer setup", a new `SurgeProposerWrapper` needs to be deployed.
- The `admin` of `SurgeProposerWrapper` needs to make the proposer and prover keys the authorized callers of this contract by calling `authorizeCaller(address)` for each of them.
- Then either the proposer or prover key may call the `depositBond(..)` function directly on the `SurgeProposerWrapper` to deposit the bond on-behalf the wrapper contract.

### What modifications are required in Taiko client?
---

Taiko-client is currently sending proposal calls to `TaikoWrapper` and bond deposits, bond withdrawals and proving calls to `TaikoInbox`. All these calls will now be sent to this `SurgeProposerWrapper` address for the proposer. The function signatures remain exactly the same.
