### PR TITLE
Fix setHeadL1Origin RPC

### DIFF
--- a/packages/taiko-client/pkg/rpc/engine.go
+++ b/packages/taiko-client/pkg/rpc/engine.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/miner"
 	"github.com/ethereum/go-ethereum/node"
@@ -148,7 +149,7 @@ func (c *EngineClient) UpdateL1Origin(ctx context.Context, l1Origin *rawdb.L1Ori
 func (c *EngineClient) SetHeadL1Origin(ctx context.Context, blockID *big.Int) (*big.Int, error) {
 	var res *big.Int
 
-	if err := c.CallContext(ctx, &res, "taikoAuth_setHeadL1Origin", blockID); err != nil {
+	if err := c.CallContext(ctx, &res, "taikoAuth_setHeadL1Origin", hexutil.EncodeBig(blockID)); err != nil {
 		return nil, err
 	}
 

--- a/packages/taiko-client/pkg/rpc/engine.go
+++ b/packages/taiko-client/pkg/rpc/engine.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
@@ -147,10 +148,15 @@ func (c *EngineClient) UpdateL1Origin(ctx context.Context, l1Origin *rawdb.L1Ori
 
 // SetHeadL1Origin sets the latest L2 block's corresponding L1 origin.
 func (c *EngineClient) SetHeadL1Origin(ctx context.Context, blockID *big.Int) (*big.Int, error) {
-	var res *big.Int
+	var response string
 
-	if err := c.CallContext(ctx, &res, "taikoAuth_setHeadL1Origin", hexutil.EncodeBig(blockID)); err != nil {
+	if err := c.CallContext(ctx, &response, "taikoAuth_setHeadL1Origin", hexutil.EncodeBig(blockID)); err != nil {
 		return nil, err
+	}
+
+	res, err := hexutil.DecodeBig(response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode taikoAuth_setHeadL1Origin response: %w", err)
 	}
 
 	return res, nil


### PR DESCRIPTION
Discovered this new issue after restarting taiko client driver:

```
INFO [07-15|13:13:15.438] "🧬 Known batch in canonical chain"    batchID=3 lastBlockID=3 lastBlockHash=3c0b38..dccf64 assignedProver=0x3e95dFbBaF6B348396E6674C7871546dCC568e56 lastTimestamp=1,752,585,048 coinbase=0xD51a7E12997f6f1D04AcCC2b4053307a62b373cb numBlobs=1 blocks=1 parentNumber=2 parentHash=21d666..a42fc8
INFO [07-15|13:13:15.440] Update head L1 origin                    blockID=3 l1Origin="&{BlockID:+3 L2BlockHash:0x3c0b38071e7134ccbc0b7461e5837cb85bb937688c97282cddd87de1d4dccf64 L1BlockHeight:+34 L1BlockHash:0x13267c91ec21dafbf188c4426f867ff297da41a0ac3c96ae3d737574a8925659 BuildPayloadArgsID:[2 132 177 36 39 255 212 197]}"
WARN [07-15|13:13:15.440] Error while processing BatchProposed events, keep retrying error="failed to update L1 origin for batch (3): failed to write head L1 origin: math/big: cannot unmarshal \"\\\"0x3\\\"\" into a *big.Int"
ERROR[07-15|13:13:15.440] Block batch iterator callback error      error="failed to update L1 origin for batch (3): failed to write head L1 origin: math/big: cannot unmarshal \"\\\"0x3\\\"\" into a *big.Int"
```

The unique thing about the issue is that this code path is only hit under a certain condition, which can be reproduced by restarting the taiko client driver. It generally doesn't occur in a regular startup of the driver, since there is no known batch already inserted in L2:

```
                                log.Info(
					"🧬 Known batch in canonical chain",
					"batchID", meta.GetBatchID(),
					"lastBlockID", meta.GetLastBlockID(),
					"lastBlockHash", lastBlockHeader.Hash(),
					"assignedProver", meta.GetProposer(),
					"lastTimestamp", meta.GetLastBlockTimestamp(),
					"coinbase", meta.GetCoinbase(),
					"numBlobs", len(meta.GetBlobHashes()),
					"blocks", len(meta.GetBlocks()),
					"parentNumber", parent.Number,
					"parentHash", parent.Hash(),
				)

				// Update the L1 origin for each block in the batch.
				if err := updateL1OriginForBatch(ctx, i.rpc, metadata); err != nil {
					return fmt.Errorf("failed to update L1 origin for batch (%d): %w", meta.GetBatchID().Uint64(), err)
				}

				return nil
```

After these code changes, verified it with local devnet:
```
INFO [07-15|14:34:14.508] "🧬 Known batch in canonical chain"    batchID=3 lastBlockID=3 lastBlockHash=3c0b38..dccf64 assignedProver=0x3e95dFbBaF6B348396E6674C7871546dCC568e56 lastTimestamp=1,752,585,048 coinbase=0xD51a7E12997f6f1D04AcCC2b4053307a62b373cb numBlobs=1 blocks=1 parentNumber=2 parentHash=21d666..a42fc8
INFO [07-15|14:34:14.509] Update head L1 origin                    blockID=3 l1Origin="&{BlockID:+3 L2BlockHash:0x3c0b38071e7134ccbc0b7461e5837cb85bb937688c97282cddd87de1d4dccf64 L1BlockHeight:+34 L1BlockHash:0x13267c91ec21dafbf188c4426f867ff297da41a0ac3c96ae3d737574a8925659 BuildPayloadArgsID:[2 132 177 36 39 255 212 197]}"
INFO [07-15|14:34:14.518] New BatchProposed event                  l1Height=61 l1Hash=f47f92..20ab56 batchID=4 lastBlockID=4 lastTimestamp=1,752,585,372 blocks=1
INFO [07-15|14:34:14.522] Fetch sidecars                           blockNumber=61 sidecars=1
```