### PR TITLE
Disable Profitability by Default

### DIFF
--- a/packages/taiko-client/cmd/flags/proposer.go
+++ b/packages/taiko-client/cmd/flags/proposer.go
@@ -105,7 +105,7 @@ var (
 	CheckProfitability = &cli.BoolFlag{
 		Name:     "checkProfitability",
 		Usage:    "Check profitability of transactions before proposing",
-		Value:    true,
+		Value:    false,
 		Category: proposerCategory,
 		EnvVars:  []string{"CHECK_PROFITABILITY"},
 	}


### PR DESCRIPTION
We currently use environment variable config for enabling/disabling profitability changes, but it should be disabled by default in the code (for example in case proposer is run as a stand alone process without the scripts/simple-surge-node): https://github.com/NethermindEth/simple-surge-node/blob/devnet/pacaya-v2/.env.devnet#L56