### PR TITLE
Add TDX prover support

### DIFF
--- a/packages/taiko-client/cmd/flags/prover.go
+++ b/packages/taiko-client/cmd/flags/prover.go
@@ -22,6 +22,13 @@ var (
 		Category: proverCategory,
 		EnvVars:  []string{"RAIKO_HOST_SGX"},
 	}
+	RaikoTDXHostEndpoint = &cli.StringFlag{
+		Name:     "raiko.host.tdx",
+		Usage:    "RPC endpoint of a Raiko TDX host service",
+		Required: true,
+		Category: proverCategory,
+		EnvVars:  []string{"RAIKO_HOST_TDX"},
+	}
 	RaikoZKVMHostEndpoint = &cli.StringFlag{
 		Name:     "raiko.host.zkvm",
 		Usage:    "RPC endpoint of a Raiko ZKVM host service",
@@ -113,6 +120,14 @@ var (
 		Category: proverCategory,
 		EnvVars:  []string{"PROVER_SGX_BATCH_SIZE"},
 	}
+	TDXBatchSize = &cli.Uint64Flag{
+		Name: "prover.tdx.batchSize",
+		Usage: "The default size of batch tdx proofs, when it arrives, submit a batch of proof immediately, " +
+			"this flag only works for post Ontake fork blocks",
+		Value:    1,
+		Category: proverCategory,
+		EnvVars:  []string{"PROVER_TDX_BATCH_SIZE"},
+	}
 	ZKVMBatchSize = &cli.Uint64Flag{
 		Name: "prover.zkvm.batchSize",
 		Usage: "The size of batch ZKVM proof, when it arrives, submit a batch of proof immediately, " +
@@ -128,6 +143,8 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	L2WSEndpoint,
 	L2HTTPEndpoint,
 	RaikoSGXHostEndpoint,
+	RaikoTDXHostEndpoint,
+	RaikoZKVMHostEndpoint,
 	RaikoJWTPath,
 	L1ProverPrivKey,
 	StartingBatchID,
@@ -139,8 +156,8 @@ var ProverFlags = MergeFlags(CommonFlags, []cli.Flag{
 	LocalProposerAddresses,
 	BlockConfirmations,
 	RaikoRequestTimeout,
-	RaikoZKVMHostEndpoint,
 	SGXBatchSize,
+	TDXBatchSize,
 	ZKVMBatchSize,
 	ForceBatchProvingInterval,
 }, TxmgrFlags)

--- a/packages/taiko-client/internal/metrics/metrics.go
+++ b/packages/taiko-client/internal/metrics/metrics.go
@@ -110,6 +110,18 @@ var (
 	ProverSgxGethProofAggregationGeneratedCounter = factory.NewCounter(prometheus.CounterOpts{
 		Name: "prover_proof_sgx_geth_aggregation_generated",
 	})
+	ProverTdxAggregationGenerationTime = factory.NewGauge(prometheus.GaugeOpts{
+		Name: "prover_proof_tdx_aggregation_generation_time",
+	})
+	ProverTdxProofGeneratedCounter = factory.NewCounter(prometheus.CounterOpts{
+		Name: "prover_proof_tdx_generated",
+	})
+	ProverTdxProofGenerationTime = factory.NewGauge(prometheus.GaugeOpts{
+		Name: "prover_proof_tdx_generation_time",
+	})
+	ProverTdxProofAggregationGeneratedCounter = factory.NewCounter(prometheus.CounterOpts{
+		Name: "prover_proof_tdx_aggregation_generated",
+	})
 	ProverR0AggregationGenerationTime = factory.NewGauge(prometheus.GaugeOpts{
 		Name: "prover_proof_r0_aggregation_generation_time",
 	})

--- a/packages/taiko-client/pkg/rpc/methods.go
+++ b/packages/taiko-client/pkg/rpc/methods.go
@@ -937,6 +937,15 @@ func (c *Client) GetSGXVerifierPacaya(opts *bind.CallOpts) (common.Address, erro
 	return getImmutableAddressFromStructPacaya(c, opts, c.PacayaClients.SurgeVerifier.SgxRethVerifier)
 }
 
+// GetTDXVerifierPacaya resolves the Pacaya tdx verifier address.
+func (c *Client) GetTDXVerifierPacaya(opts *bind.CallOpts) (common.Address, error) {
+	if c.PacayaClients.SurgeVerifier == nil {
+		return common.Address{}, errors.New("surgeVerifier contract is not set")
+	}
+
+	return getImmutableAddressFromStructPacaya(c, opts, c.PacayaClients.SurgeVerifier.TdxNethermindVerifier)
+}
+
 // GetRISC0VerifierPacaya resolves the Pacaya risc0 verifier address.
 func (c *Client) GetRISC0VerifierPacaya(opts *bind.CallOpts) (common.Address, error) {
 	if c.PacayaClients.SurgeVerifier == nil {

--- a/packages/taiko-client/prover/config.go
+++ b/packages/taiko-client/prover/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	ProveBatchesGasLimit        uint64
 	Allowance                   *big.Int
 	RaikoSGXHostEndpoint        string
+	RaikoTDXHostEndpoint        string
 	RaikoZKVMHostEndpoint       string
 	RaikoJWT                    string
 	RaikoRequestTimeout         time.Duration
@@ -45,6 +46,7 @@ type Config struct {
 	TxmgrConfigs                *txmgr.CLIConfig
 	PrivateTxmgrConfigs         *txmgr.CLIConfig
 	SGXProofBufferSize          uint64
+	TDXProofBufferSize          uint64
 	ZKVMProofBufferSize         uint64
 	ForceBatchProvingInterval   time.Duration
 	ProofPollingInterval        time.Duration
@@ -106,6 +108,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 		SurgeProposerWrapperAddress: common.HexToAddress(c.String(flags.SurgeProposerWrapperAddress.Name)),
 		L1ProverPrivKey:             l1ProverPrivKey,
 		RaikoSGXHostEndpoint:        c.String(flags.RaikoSGXHostEndpoint.Name),
+		RaikoTDXHostEndpoint:        c.String(flags.RaikoTDXHostEndpoint.Name),
 		RaikoZKVMHostEndpoint:       c.String(flags.RaikoZKVMHostEndpoint.Name),
 		RaikoJWT:                    common.Bytes2Hex(jwtSecret),
 		RaikoRequestTimeout:         c.Duration(flags.RaikoRequestTimeout.Name),
@@ -126,6 +129,7 @@ func NewConfigFromCliContext(c *cli.Context) (*Config, error) {
 			c,
 		),
 		SGXProofBufferSize:        c.Uint64(flags.SGXBatchSize.Name),
+		TDXProofBufferSize:        c.Uint64(flags.TDXBatchSize.Name),
 		ZKVMProofBufferSize:       c.Uint64(flags.ZKVMBatchSize.Name),
 		ForceBatchProvingInterval: c.Duration(flags.ForceBatchProvingInterval.Name),
 		ProofPollingInterval:      c.Duration(flags.ProofPollingInterval.Name),

--- a/packages/taiko-client/prover/config_test.go
+++ b/packages/taiko-client/prover/config_test.go
@@ -30,6 +30,7 @@ func (s *ProverTestSuite) SetupApp() *cli.App {
 		&cli.DurationFlag{Name: flags.RPCTimeout.Name},
 		&cli.StringFlag{Name: flags.Allowance.Name},
 		&cli.StringFlag{Name: flags.RaikoSGXHostEndpoint.Name},
+		&cli.StringFlag{Name: flags.RaikoTDXHostEndpoint.Name},
 	}
 	app.Flags = append(app.Flags, flags.TxmgrFlags...)
 	app.Action = func(ctx *cli.Context) error {

--- a/packages/taiko-client/prover/proof_producer/common.go
+++ b/packages/taiko-client/prover/proof_producer/common.go
@@ -143,6 +143,9 @@ func updateProvingMetrics(proofType ProofType, requestAt time.Time, isAggregatio
 		case ProofTypeSgx:
 			metrics.ProverSGXAggregationGenerationTime.Set(float64(time.Since(requestAt).Seconds()))
 			metrics.ProverSgxProofAggregationGeneratedCounter.Add(1)
+		case ProofTypeTdx:
+			metrics.ProverTdxAggregationGenerationTime.Set(float64(time.Since(requestAt).Seconds()))
+			metrics.ProverTdxProofAggregationGeneratedCounter.Add(1)
 		case ProofTypeZKR0:
 			metrics.ProverR0AggregationGenerationTime.Set(float64(time.Since(requestAt).Seconds()))
 			metrics.ProverR0ProofAggregationGeneratedCounter.Add(1)
@@ -162,6 +165,9 @@ func updateProvingMetrics(proofType ProofType, requestAt time.Time, isAggregatio
 		case ProofTypeSgx:
 			metrics.ProverSgxProofGenerationTime.Set(float64(time.Since(requestAt).Seconds()))
 			metrics.ProverSgxProofGeneratedCounter.Add(1)
+		case ProofTypeTdx:
+			metrics.ProverTdxProofGenerationTime.Set(float64(time.Since(requestAt).Seconds()))
+			metrics.ProverTdxProofGeneratedCounter.Add(1)
 		case ProofTypeZKR0:
 			metrics.ProverR0ProofGenerationTime.Set(float64(time.Since(requestAt).Seconds()))
 			metrics.ProverR0ProofGeneratedCounter.Add(1)

--- a/packages/taiko-client/prover/proof_producer/interface.go
+++ b/packages/taiko-client/prover/proof_producer/interface.go
@@ -15,6 +15,7 @@ const (
 	ProofTypeSgxGeth ProofType = "sgxgeth"
 	ProofTypeOp      ProofType = "op"
 	ProofTypeSgx     ProofType = "sgx"
+	ProofTypeTdx     ProofType = "tdx"
 	ProofTypeSgxCPU  ProofType = "native"
 	ProofTypeZKR0    ProofType = "risc0"
 	ProofTypeZKSP1   ProofType = "sp1"
@@ -42,6 +43,9 @@ type ProofRequestOptionsPacaya struct {
 
 	IsRethSGXProofGenerated            bool
 	IsRethSGXProofAggregationGenerated bool
+
+	IsNethermindTdxProofGenerated            bool
+	IsNethermindTdxProofAggregationGenerated bool
 
 	IsRethZKProofGenerated            bool
 	IsRethZKProofAggregationGenerated bool

--- a/packages/taiko-client/prover/proof_producer/proof_producer.go
+++ b/packages/taiko-client/prover/proof_producer/proof_producer.go
@@ -43,6 +43,8 @@ type BatchProofs struct {
 	Verifier         common.Address
 	SgxBatchProof    []byte
 	SgxProofVerifier common.Address
+	TdxBatchProof    []byte
+	TdxProofVerifier common.Address
 }
 
 // ProofProducer is an interface that contains all methods to generate a proof.

--- a/packages/taiko-client/prover/proof_submitter/proof_submitter.go
+++ b/packages/taiko-client/prover/proof_submitter/proof_submitter.go
@@ -176,8 +176,8 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 					// If zk proof is not drawn
 					log.Debug("ZK proof was not chosen for some reason, check raiko host", "batchID", opts.BatchID)
 				}
-				log.Debug("Failed to request SGX + ZK proofs, retrying", "batchID", opts.BatchID, "error", err)
-				return fmt.Errorf("failed to request sgx + zk proofs, error: %w", err)
+				log.Debug("Failed to request SGX + TDX + ZK proofs, retrying", "batchID", opts.BatchID, "error", err)
+				return fmt.Errorf("failed to request sgx + tdx + zk proofs, error: %w", err)
 			}
 
 			// Try to add the proof to the buffer.
@@ -195,7 +195,7 @@ func (s *ProofSubmitterPacaya) RequestProof(ctx context.Context, meta metadata.T
 				)
 			}
 			log.Info(
-				"Proof generated (SGX + ZK)",
+				"Proof generated (SGX + TDX + ZK)",
 				"batchID", meta.Pacaya().GetBatchID(),
 				"bufferSize", bufferSize,
 				"maxBufferSize", proofBuffer.MaxLength,
@@ -318,7 +318,7 @@ func (s *ProofSubmitterPacaya) AggregateProofsByType(ctx context.Context, proofT
 	// nolint:exhaustive
 	// We deliberately handle only known proof types and catch others in default case
 	switch proofType {
-	case proofProducer.ProofTypeSgx, proofProducer.ProofTypeZKR0, proofProducer.ProofTypeZKSP1:
+	case proofProducer.ProofTypeSgx, proofProducer.ProofTypeTdx, proofProducer.ProofTypeZKR0, proofProducer.ProofTypeZKSP1:
 		producer = s.proofProducer
 	default:
 		return fmt.Errorf("unknown proof type: %s", proofType)
@@ -339,7 +339,7 @@ func (s *ProofSubmitterPacaya) AggregateProofsByType(ctx context.Context, proofT
 			if err != nil {
 				if errors.Is(err, proofProducer.ErrProofInProgress) || errors.Is(err, proofProducer.ErrRetry) {
 					log.Debug(
-						"Aggregating proofs (SGX + ZK)",
+						"Aggregating proofs (SGX + TDX + ZK)",
 						"status", err,
 						"batchSize", len(buffer),
 						"firstID", buffer[0].BatchID,

--- a/packages/taiko-client/prover/proof_submitter/transaction/builder.go
+++ b/packages/taiko-client/prover/proof_submitter/transaction/builder.go
@@ -77,8 +77,10 @@ func (a *ProveBatchesTxBuilder) BuildProveBatchesPacaya(batchProof *proofProduce
 				"gasLimit", txOpts.GasLimit,
 				"verifier", batchProof.Verifier,
 				"sgxVerifier", batchProof.SgxProofVerifier,
+				"tdxVerifier", batchProof.TdxProofVerifier,
 			)
 		}
+		// TODO: add TDX here
 		if bytes.Compare(batchProof.Verifier.Bytes(), batchProof.SgxProofVerifier.Bytes()) < 0 {
 			subProofs[0] = encoding.SubProof{
 				ProofType: encoding.GetProofTypeFromString(string(batchProof.ProofType)),
@@ -145,6 +147,7 @@ func (a *ProveBatchesTxBuilder) BuildProveBatchesPacaya(batchProof *proofProduce
 			"zkProofType", batchProof.ProofType,
 			"zkBatchProofLength", len(batchProof.BatchProof),
 			"sgxBatchProofLength", len(batchProof.SgxBatchProof),
+			"tdxBatchProofLength", len(batchProof.TdxBatchProof),
 		)
 
 		return &txmgr.TxCandidate{

--- a/packages/taiko-client/prover/prover_test.go
+++ b/packages/taiko-client/prover/prover_test.go
@@ -181,6 +181,7 @@ func (s *ProverTestSuite) TestSubmitProofAggregationOp() {
 				BatchIDs:      []*big.Int{common.Big1},
 				ProofType:     proofProducer.ProofTypeOp,
 				SgxBatchProof: []byte{},
+				TdxBatchProof: []byte{},
 			})
 		})
 	})
@@ -352,6 +353,7 @@ func (s *ProverTestSuite) TestAggregateProofsAlreadyProved() {
 		BackOffRetryInterval:  3 * time.Second,
 		BackOffMaxRetries:     12,
 		SGXProofBufferSize:    uint64(batchSize),
+		TDXProofBufferSize:    uint64(batchSize),
 	}, s.txmgr, s.txmgr))
 
 	for i := 0; i < batchSize; i++ {
@@ -408,6 +410,7 @@ func (s *ProverTestSuite) TestAggregateProofs() {
 		BackOffRetryInterval:  3 * time.Second,
 		BackOffMaxRetries:     12,
 		SGXProofBufferSize:    uint64(batchSize),
+		TDXProofBufferSize:    uint64(batchSize),
 	}, s.txmgr, s.txmgr))
 
 	for i := 0; i < batchSize; i++ {
@@ -461,6 +464,7 @@ func (s *ProverTestSuite) TestForceAggregate() {
 		BackOffRetryInterval:      3 * time.Second,
 		BackOffMaxRetries:         12,
 		SGXProofBufferSize:        uint64(batchSize),
+		TDXProofBufferSize:        uint64(batchSize),
 		ForceBatchProvingInterval: 5 * time.Second,
 	}, s.txmgr, s.txmgr))
 
@@ -698,6 +702,7 @@ func (s *ProverTestSuite) initProver(ctx context.Context, key *ecdsa.PrivateKey)
 		BackOffRetryInterval:  3 * time.Second,
 		BackOffMaxRetries:     12,
 		SGXProofBufferSize:    1,
+		TDXProofBufferSize:    1,
 		ZKVMProofBufferSize:   1,
 		BlockConfirmations:    0,
 	}, s.txmgr, s.txmgr))


### PR DESCRIPTION
This PR adds TDX prover support to the prover relayer and smart contracts.
It's important to notice that, by adding some more flags to the prover relayer command and more smart contracts, this PR will then require some work on the deployment side to incorporate these changes.

Keeping this as draft as it's in progress.