### PR TITLE
fix: align mock proof verifier with SurgeVerifier pipeline

### DIFF
--- a/packages/protocol/contracts/layer1/surge/SurgeVerifier.sol
+++ b/packages/protocol/contracts/layer1/surge/SurgeVerifier.sol
@@ -15,9 +15,10 @@ contract SurgeVerifier is Ownable2Step {
     // Proof bitflags for LibProofBitmap
     // ---------------------------------------------------------------
 
-    uint8 public constant RISC0_RETH = 1; // 0b00000001
-    uint8 public constant SP1_RETH = 1 << 1; // 0b00000010
-    uint8 public constant ZISK_RETH = 1 << 2; // 0b00000100
+    uint8 public constant MOCK_ECDSA = 1; // 0b00000001
+    uint8 public constant RISC0_RETH = 1 << 1; // 0b00000010
+    uint8 public constant SP1_RETH = 1 << 2; // 0b00000100
+    uint8 public constant ZISK_RETH = 1 << 3; // 0b00001000
 
     // ---------------------------------------------------------------
     // Types and storage

--- a/packages/protocol/script/layer1/surge/DeployRealTimeSurgeL1.s.sol
+++ b/packages/protocol/script/layer1/surge/DeployRealTimeSurgeL1.s.sol
@@ -54,9 +54,6 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
     // ---------------------------------------------------------------
     bool internal immutable mockProofMode = vm.envOr("MOCK_PROOF_MODE", false);
     address internal immutable mockProofSigner = vm.envOr("MOCK_PROOF_SIGNER", address(0));
-    /// @dev Bit flag to register the dummy verifier under (default: ZISK_RETH = 4).
-    ///      Must match PROOF_TYPE in the Catalyst .env.
-    uint8 internal immutable mockProofBitFlag = uint8(vm.envOr("MOCK_PROOF_BIT_FLAG", uint256(4)));
 
     // SurgeVerifier configuration
     // ---------------------------------------------------------------
@@ -254,14 +251,14 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
         ProofVerifierDummy dummy = new ProofVerifierDummy(mockProofSigner, l2ChainId);
         console2.log("** Deployed ProofVerifierDummy:", address(dummy));
         console2.log("** Mock proof signer:", mockProofSigner);
-        console2.log("** Mock proof bit flag:", mockProofBitFlag);
         writeJson("proof_verifier_dummy", address(dummy));
 
-        // Register in SurgeVerifier under the configured bit flag
-        SurgeVerifier(_rollupContracts.proofVerifier).setVerifier(
-            LibProofBitmap.ProofBitmap.wrap(mockProofBitFlag), address(dummy)
+        // Register in SurgeVerifier under the MOCK_ECDSA bit flag
+        SurgeVerifier surgeVerifier = SurgeVerifier(_rollupContracts.proofVerifier);
+        surgeVerifier.setVerifier(
+            LibProofBitmap.ProofBitmap.wrap(surgeVerifier.MOCK_ECDSA()), address(dummy)
         );
-        console2.log("** Registered dummy verifier in SurgeVerifier");
+        console2.log("** Registered dummy verifier in SurgeVerifier (MOCK_ECDSA)");
     }
 
     /// @dev The deployer is the initial owner of the Zisk verifier.

--- a/packages/protocol/script/layer1/surge/DeployRealTimeSurgeL1.s.sol
+++ b/packages/protocol/script/layer1/surge/DeployRealTimeSurgeL1.s.sol
@@ -54,6 +54,9 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
     // ---------------------------------------------------------------
     bool internal immutable mockProofMode = vm.envOr("MOCK_PROOF_MODE", false);
     address internal immutable mockProofSigner = vm.envOr("MOCK_PROOF_SIGNER", address(0));
+    /// @dev Bit flag to register the dummy verifier under (default: ZISK_RETH = 4).
+    ///      Must match PROOF_TYPE in the Catalyst .env.
+    uint8 internal immutable mockProofBitFlag = uint8(vm.envOr("MOCK_PROOF_BIT_FLAG", uint256(4)));
 
     // SurgeVerifier configuration
     // ---------------------------------------------------------------
@@ -110,10 +113,12 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
         // ---------------------------------------------------------------
         RollupContracts memory rollupContracts = deployRollupContracts(emptyImpl);
 
-        // Deploy internal verifiers (needed for SurgeVerifier, skipped in mock mode)
+        // Deploy internal verifiers
         // ---------------------------------------------------------------
         VerifierContracts memory verifierContracts;
-        if (!mockProofMode) {
+        if (mockProofMode) {
+            verifierContracts = deployMockVerifier(rollupContracts);
+        } else {
             verifierContracts = deployInternalVerifiers(contractOwner);
         }
 
@@ -125,10 +130,15 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
         // Register L2 addresses in the resolver
         setupSharedResolver(sharedContracts, contractOwner);
 
-        // Setup proof verifier with internal verifiers (skipped in mock mode)
+        // Setup proof verifier with internal verifiers
+        // (mock mode already registered the dummy in deployMockVerifier)
         // ---------------------------------------------------------------
         if (!mockProofMode) {
             setupProofVerifier(rollupContracts, verifierContracts, contractOwner);
+        } else {
+            // Transfer SurgeVerifier ownership
+            SurgeVerifier(rollupContracts.proofVerifier).transferOwnership(contractOwner);
+            console2.log("** SurgeVerifier ownership transfer initiated to:", contractOwner);
         }
 
         // Deploy inbox implementation and activate
@@ -226,19 +236,32 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
         // ---------------------------------------------------------------
         rollupContracts.inbox = deployProxy({ name: "real_time_inbox", impl: _emptyImpl, data: "" });
 
-        // Deploy proof verifier
+        // Deploy proof verifier — always SurgeVerifier so the inbox type cast works.
+        // In mock mode the dummy is registered as a sub-verifier below.
         // ---------------------------------------------------------------
-        if (mockProofMode) {
-            rollupContracts.proofVerifier = address(new ProofVerifierDummy(mockProofSigner));
-            console2.log("** Deployed ProofVerifierDummy:", rollupContracts.proofVerifier);
-            console2.log("** Mock proof signer:", mockProofSigner);
-            writeJson("proof_verifier_dummy", rollupContracts.proofVerifier);
-        } else {
-            rollupContracts.proofVerifier =
-                address(new SurgeVerifier(rollupContracts.inbox, numProofsThreshold, msg.sender));
-            console2.log("** Deployed SurgeVerifier:", rollupContracts.proofVerifier);
-            writeJson("surge_verifier", rollupContracts.proofVerifier);
-        }
+        rollupContracts.proofVerifier =
+            address(new SurgeVerifier(rollupContracts.inbox, numProofsThreshold, msg.sender));
+        console2.log("** Deployed SurgeVerifier:", rollupContracts.proofVerifier);
+        writeJson("surge_verifier", rollupContracts.proofVerifier);
+    }
+
+    /// @dev Deploys the ECDSA dummy verifier and registers it in SurgeVerifier
+    ///      under the configured proof bit flag so the offchain pipeline works unchanged.
+    function deployMockVerifier(RollupContracts memory _rollupContracts)
+        private
+        returns (VerifierContracts memory verifierContracts)
+    {
+        ProofVerifierDummy dummy = new ProofVerifierDummy(mockProofSigner, l2ChainId);
+        console2.log("** Deployed ProofVerifierDummy:", address(dummy));
+        console2.log("** Mock proof signer:", mockProofSigner);
+        console2.log("** Mock proof bit flag:", mockProofBitFlag);
+        writeJson("proof_verifier_dummy", address(dummy));
+
+        // Register in SurgeVerifier under the configured bit flag
+        SurgeVerifier(_rollupContracts.proofVerifier).setVerifier(
+            LibProofBitmap.ProofBitmap.wrap(mockProofBitFlag), address(dummy)
+        );
+        console2.log("** Registered dummy verifier in SurgeVerifier");
     }
 
     /// @dev The deployer is the initial owner of the Zisk verifier.
@@ -400,9 +423,8 @@ contract DeployRealTimeSurgeL1 is DeployCapability {
         ownerContracts[4] = _sharedContracts.erc1155Vault;
 
         // Build list of contracts with pending ownership transfer
-        // In mock mode, proofVerifier and ziskRethVerifier are not ownable
         address[] memory pendingOwnerContracts = new address[](4);
-        pendingOwnerContracts[0] = mockProofMode ? address(0) : _rollupContracts.proofVerifier;
+        pendingOwnerContracts[0] = _rollupContracts.proofVerifier;
         pendingOwnerContracts[1] = _rollupContracts.inbox;
         pendingOwnerContracts[2] = _sharedContracts.sharedResolver;
         pendingOwnerContracts[3] = mockProofMode ? address(0) : _verifierContracts.ziskRethVerifier;

--- a/packages/protocol/script/layer1/surge/DeploySurgeL1.s.sol
+++ b/packages/protocol/script/layer1/surge/DeploySurgeL1.s.sol
@@ -311,7 +311,7 @@ contract DeploySurgeL1 is DeployCapability {
         if (useDummyVerifier) {
             require(dummyVerifierSigner != address(0), "config: DUMMY_VERIFIER_SIGNER");
 
-            ProofVerifierDummy dummyVerifier = new ProofVerifierDummy(dummyVerifierSigner);
+            ProofVerifierDummy dummyVerifier = new ProofVerifierDummy(dummyVerifierSigner, l2ChainId);
             address dummyAddr = address(dummyVerifier);
             writeJson("proof_verifier_dummy", dummyAddr);
             console2.log("** Deployed ProofVerifierDummy:", dummyAddr);

--- a/packages/protocol/script/layer1/surge/common/ProofVerifierDummy.sol
+++ b/packages/protocol/script/layer1/surge/common/ProofVerifierDummy.sol
@@ -3,9 +3,15 @@ pragma solidity ^0.8.24;
 
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { IProofVerifier } from "src/layer1/verifiers/IProofVerifier.sol";
+import { LibPublicInput } from "src/layer1/verifiers/LibPublicInput.sol";
 
 /// @title ProofVerifierDummy
-/// @dev Dummy verifier that accepts ECDSA signatures from a trusted signer
+/// @dev Signature-based verifier that sits behind SurgeVerifier as a sub-verifier.
+///      Mirrors the public-input hashing of real verifiers (ZiskVerifier, SP1Verifier)
+///      so the offchain pipeline (Raiko → Catalyst → SubProof encoding) works unchanged.
+///
+///      Public input: hash("VERIFY_PROOF", chainId, address(this), commitmentHash, address(0))
+///      _proof:       65-byte ECDSA signature over that public input from the trusted signer.
 /// @custom:security-contact security@nethermind.io
 contract ProofVerifierDummy is IProofVerifier {
     using ECDSA for bytes32;
@@ -13,10 +19,15 @@ contract ProofVerifierDummy is IProofVerifier {
     /// @notice The trusted signer address
     address public immutable signer;
 
+    /// @notice The L2 chain id (same as real verifiers)
+    uint64 public immutable taikoChainId;
+
     /// @param _signer The trusted signer address
-    constructor(address _signer) {
+    /// @param _taikoChainId The L2 chain id used in public input hashing
+    constructor(address _signer, uint64 _taikoChainId) {
         if (_signer == address(0)) revert InvalidSigner();
         signer = _signer;
+        taikoChainId = _taikoChainId;
     }
 
     /// @inheritdoc IProofVerifier
@@ -28,7 +39,16 @@ contract ProofVerifierDummy is IProofVerifier {
         external
         view
     {
-        address recoveredSigner = _commitmentHash.recover(_proof);
+        // Hash public input identically to ZiskVerifier / SP1Verifier so
+        // the same Raiko signing pipeline produces a valid signature.
+        bytes32 publicInput = LibPublicInput.hashPublicInputs(
+            _commitmentHash,
+            address(this), // verifier contract address
+            address(0), // proofSigner (not used for non-SGX)
+            taikoChainId
+        );
+
+        address recoveredSigner = publicInput.recover(_proof);
         if (recoveredSigner != signer) revert InvalidSignature();
     }
 


### PR DESCRIPTION
## Summary
- `ProofVerifierDummy` now hashes public input via `LibPublicInput.hashPublicInputs` (matching ZiskVerifier/SP1Verifier) so Raiko's signing pipeline works unchanged
- Constructor takes `taikoChainId` param for public input derivation
- Deploy script always deploys `SurgeVerifier` (fixes inbox type-cast mismatch), registers `ProofVerifierDummy` as sub-verifier in mock mode under `MOCK_ECDSA`
- New `MOCK_ECDSA` bit flag (0b00000001) in `SurgeVerifier`; existing flags shifted up by 1 bit: RISC0=2, SP1=4, ZISK=8

## Test plan
- [ ] Deploy with `MOCK_PROOF_MODE=true` and `MOCK_PROOF_SIGNER` set
- [ ] Verify `SurgeVerifier` is deployed (not `ProofVerifierDummy` directly)
- [ ] Submit a proposal with Raiko ECDSA proof — should pass `ProofVerifierDummy.verifyProof`
- [ ] Verify non-mock deploy still registers real verifiers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)