### PR TITLE
fix(cross-chain-dex-ui): drop backdrop-blur on tx overlay to unstick spinner

### DIFF
--- a/packages/cross-chain-dex-ui/src/components/TxStatusOverlay.tsx
+++ b/packages/cross-chain-dex-ui/src/components/TxStatusOverlay.tsx
@@ -477,8 +477,8 @@ export function TxStatusOverlay({ state, onClose }: TxStatusOverlayProps) {
 function Backdrop({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm"
-      style={{ backgroundColor: 'rgba(23, 35, 66, 0.42)' }}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(23, 35, 66, 0.65)' }}
     >
       {children}
     </div>


### PR DESCRIPTION
## Summary
- The Surge rebrand (#295) added `backdrop-blur-sm` to the `TxStatusOverlay` backdrop. `backdrop-filter` forces the browser to recompute the blur of everything behind the overlay every frame, which prevents the continuously spinning rings (`transform: rotate`, 0.85s linear infinite) from staying on their own GPU compositing layer — each rotation step triggers a full re-composite, dropping the framerate and producing the slow/jittery animation users observed.
- Remove the blur and bump the solid navy backdrop from `0.42` → `0.65` opacity so the modal still reads clearly as an overlay without the per-frame blur cost.

## Test plan
- [ ] `pnpm --filter @taiko/cross-chain-dex-ui dev`, trigger a swap, and verify the active-step spinner ring rotates smoothly through the timeline (signing → sequencing → proving → proposing → complete) at a steady ~60fps
- [ ] Verify the modal backdrop still reads as a clear navy overlay over the swap card

🤖 Generated with [Claude Code](https://claude.com/claude-code)