### PR TITLE
fix(cross-chain-dex-ui): scope smart wallet UI to L1 network only

### DIFF
--- a/packages/cross-chain-dex-ui/src/App.tsx
+++ b/packages/cross-chain-dex-ui/src/App.tsx
@@ -83,22 +83,21 @@ function AppContent() {
     setDismissedWalletSetup(false);
   }, [isConnected, ownerAddress]);
 
-  // Auto-show wallet setup if connected, on correct network, but no smart wallet
+  // Auto-show wallet setup if connected on L1 with no smart wallet.
+  // On L2, swaps use the connected EOA — smart wallet is an L1-only feature.
   useEffect(() => {
-    if (isConnected && !isWrongNetwork && !smartWallet && !isLoading && !dismissedWalletSetup && accountMode === 'safe' && !showModeSelector) {
+    if (isConnected && selectedNetwork === 'l1' && !isWrongNetwork && !smartWallet && !isLoading && !dismissedWalletSetup && accountMode === 'safe' && !showModeSelector) {
       setShowWalletSetup(true);
     } else if (smartWallet && showWalletSetup) {
       setShowWalletSetup(false);
     }
-  }, [isConnected, isWrongNetwork, smartWallet, isLoading, showWalletSetup, dismissedWalletSetup, accountMode, showModeSelector]);
+  }, [isConnected, isWrongNetwork, smartWallet, isLoading, showWalletSetup, dismissedWalletSetup, accountMode, showModeSelector, selectedNetwork]);
 
-  // Auto-show fund wallet modal.
-  // On L2, suppress until the L2 Safe actually exists — creation is initiated from L1
-  // via the bridge, so funding an undeployed L2 address is a dead-end for the user.
+  // Auto-show fund wallet modal — L1 only (smart wallet is L1-only feature).
   useEffect(() => {
+    if (selectedNetwork !== 'l1') return;
     if (accountMode === 'ambire') return;
     if (!smartWallet || hasShownFundModal || balancesLoading || isLoading || showNetworkSetup || showWalletSetup) return;
-    if (selectedNetwork === 'l2' && !l2WalletExists) return;
     const needsFunding = ethBalance === 0n || usdcBalance === 0n;
     const needsL2 = accountMode === 'safe' && !l2WalletExists;
     if (needsFunding || needsL2) {
@@ -183,13 +182,13 @@ function AppContent() {
       />
 
       <AccountModeSelector
-        isOpen={showModeSelector}
+        isOpen={showModeSelector && selectedNetwork === 'l1'}
         onSelect={selectAccountMode}
         onClose={() => setShowModeSelector(false)}
       />
 
       <SmartWalletSetup
-        isOpen={showWalletSetup && !isWrongNetwork && !showModeSelector}
+        isOpen={showWalletSetup && !isWrongNetwork && !showModeSelector && selectedNetwork === 'l1'}
         onClose={() => {
           setShowWalletSetup(false);
           setDismissedWalletSetup(true);
@@ -199,7 +198,7 @@ function AppContent() {
         createSmartWallet={createSmartWallet}
       />
 
-      {smartWallet && (
+      {smartWallet && selectedNetwork === 'l1' && (
         <FundWallet
           isOpen={showFundWallet}
           onClose={() => setShowFundWallet(false)}

--- a/packages/cross-chain-dex-ui/src/components/Header.tsx
+++ b/packages/cross-chain-dex-ui/src/components/Header.tsx
@@ -14,7 +14,7 @@ interface HeaderProps {
 }
 
 export function Header({ onSetupWallet }: HeaderProps) {
-  const { smartWallet, isConnected, ownerAddress, accountMode, clearAccountMode, selectedNetwork, setSelectedNetwork, l2WalletExists } = useSmartWallet();
+  const { smartWallet, isConnected, ownerAddress, accountMode, clearAccountMode, selectedNetwork, setSelectedNetwork } = useSmartWallet();
   const { address: eoaAddress } = useAccount();
   const { disconnect } = useDisconnect();
   const { executeWithdraw, isPending } = useUserOp(accountMode);
@@ -112,18 +112,8 @@ export function Header({ onSetupWallet }: HeaderProps) {
       </div>
 
       <div className="flex items-center gap-3">
-        {/* Smart Wallet: show "Setup on L2" button when on L2 network and L2 wallet doesn't exist */}
-        {isConnected && smartWallet && selectedNetwork === 'l2' && !l2WalletExists && (
-          <button
-            onClick={onSetupWallet}
-            className="px-4 py-2 bg-surge-secondary/15 hover:bg-surge-secondary/25 text-surge-primary rounded-lg text-sm font-medium transition-colors border border-surge-secondary/40"
-          >
-            Setup Smart Wallet on L2
-          </button>
-        )}
-
-        {/* Smart Wallet display — show when wallet exists on the selected network */}
-        {isConnected && smartWallet && (selectedNetwork === 'l1' || l2WalletExists) && (
+        {/* Smart Wallet display — L1 only (swaps on L2 use the connected EOA) */}
+        {isConnected && smartWallet && selectedNetwork === 'l1' && (
           <div className="hidden md:flex items-center relative" ref={swDropdownRef}>
             <div className="flex items-center gap-2 px-3 py-2 bg-surge-card rounded-lg border border-surge-border">
               <div className="w-2 h-2 bg-surge-mint rounded-full" />
@@ -179,7 +169,7 @@ export function Header({ onSetupWallet }: HeaderProps) {
           </div>
         )}
 
-        {isConnected && !smartWallet && (
+        {isConnected && !smartWallet && selectedNetwork === 'l1' && (
           <button
             onClick={onSetupWallet}
             className="px-4 py-2 bg-surge-primary hover:opacity-90 text-white rounded-lg text-sm font-medium transition-opacity shadow-sm"


### PR DESCRIPTION
## Summary
Swaps on Surge L2 are signed by the connected EOA, so the smart wallet is irrelevant on L2. Hide all smart wallet surfaces when the user is on L2:

- **Header**: drop the smart wallet pill, withdraw dropdown, "Setup Smart Wallet" button, and the "Setup Smart Wallet on L2" button
- **App.tsx auto-popup effects**: gate the SmartWalletSetup and FundWallet auto-show effects on \`selectedNetwork === 'l1'\`
- **App.tsx render gates**: \`AccountModeSelector\`, \`SmartWalletSetup\`, and \`FundWallet\` are render-gated on L1 so a stale flag from a previous L1 session can't surface a popup after switching to L2

The L1 bridge "Withdraw L2 → L1" flow still creates the L2 Safe via the L1 FundWallet — that path is untouched.

## Test plan
- [ ] Connect wallet on Surge L1 — smart wallet pill, "Setup Smart Wallet", and the FundWallet popup should appear as before
- [ ] Switch to Surge L2 — header should show no smart wallet UI; no SmartWalletSetup, FundWallet, or AccountModeSelector popup should appear
- [ ] On L1 with no L2 Safe deployed, open the bridge → "Withdraw L2 → L1" — the FundWallet's "Create L2 Wallet" CTA should still work
- [ ] Switch back to L1 — smart wallet UI re-appears; popups behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)