### PR TITLE
fix(cross-chain-dex-ui): submit Safe bridge-out as direct L2 tx

### DIFF
--- a/packages/cross-chain-dex-ui/src/App.tsx
+++ b/packages/cross-chain-dex-ui/src/App.tsx
@@ -62,8 +62,15 @@ function AppContent() {
   // Only show network setup if on a completely unknown chain (neither L1 nor L2).
   // If the user is on a valid chain but not the one matching the selected network,
   // silently auto-switch without showing the modal.
+  //
+  // While a tx is in flight (e.g. a bridge withdrawal triggered from the L1 page that
+  // needs to sign on L2), suppress the auto-switch so we don't fight the in-flight
+  // hook-driven chain switch. Once the tx settles ('complete' / 'rejected' / 'idle'),
+  // the effect re-fires and pulls the wallet back to the selected page network.
+  const isTxInFlight = txStatus.phase !== 'idle' && txStatus.phase !== 'complete' && txStatus.phase !== 'rejected';
   useEffect(() => {
     if (!isConnected || !chainId) return;
+    if (isTxInFlight) return;
     if (isWrongNetwork) {
       // On an unknown chain — try to switch, show modal if that fails
       switchChainAsync({ chainId: requiredChainId }).catch(() => {
@@ -76,7 +83,7 @@ function AppContent() {
     } else {
       setShowNetworkSetup(false);
     }
-  }, [isConnected, chainId, requiredChainId, isWrongNetwork, switchChainAsync]);
+  }, [isConnected, chainId, requiredChainId, isWrongNetwork, switchChainAsync, isTxInFlight]);
 
   // Reset dismissed flag when wallet connects/disconnects
   useEffect(() => {

--- a/packages/cross-chain-dex-ui/src/hooks/useUserOp.ts
+++ b/packages/cross-chain-dex-ui/src/hooks/useUserOp.ts
@@ -142,6 +142,27 @@ export function useUserOp(accountMode: AccountMode = 'safe'): UseUserOpReturn {
           setTxStatus({ phase: 'sequencing' });
           await l2PublicClient.waitForTransactionReceipt({ hash: txHash });
           return await pollStatus({ txHash });
+        } else if (accountMode === 'safe' && targetChainId === L2_CHAIN_ID) {
+          // Safe on L2 (e.g. bridge-out L2 -> L1): standard L2 tx — sign safeTx
+          // and submit Safe.execTransaction directly. The L1 UserOp builder is
+          // not involved; the bridge message emitted on L2 is delivered to L1
+          // by the relayer asynchronously.
+          const nonce = await getSafeNonce(publicClient, smartWallet);
+          const safeTx = userOpsToSafeTx(ops);
+          const typedData = buildSafeTxTypedData(smartWallet, targetChainId, nonce, safeTx);
+          const signature = await activeClient.signTypedData(typedData);
+          const execCalldata = buildExecTransactionCalldata(safeTx, signature as Hex);
+          const txHash = await activeClient.sendTransaction({
+            to: smartWallet,
+            data: execCalldata,
+            chain: activeClient.chain,
+            account: activeClient.account,
+          });
+          setTxStatus({ phase: 'sequencing' });
+          await l2PublicClient.waitForTransactionReceipt({ hash: txHash });
+          setTxStatus({ phase: 'complete', txHash });
+          setIsPending(false);
+          return true;
         } else if (accountMode === 'ambire') {
           // AmbireAccount path on L1: personal_sign + execute()
           const txns = userOpsToAmbireTransactions(ops);


### PR DESCRIPTION
## Summary
Bridge-out (L2 → L1) was being routed through the L1 UserOp builder via \`executeGenericOps\`, which rejected it with **\"L1 UserOp with no bridge message\"** because the builder only handles real-time-proven L1 ops. The bridge-out is a standard L2 transaction that emits a bridge message delivered to L1 by the relayer asynchronously.

- Add a Safe-on-L2 branch in \`executeGenericOps\` that signs the SafeTx with the L2 EIP-712 domain and submits \`Safe.execTransaction\` directly via \`walletClient.sendTransaction\`, mirroring the existing Ambire-on-L2 direct-send path. Phase progression is \`signing → sequencing → complete\` once the L2 receipt lands; the builder is bypassed entirely.
- Pause the App-level auto-switch effect while a tx is in flight (\`txStatus.phase\` ≠ \`idle\` / \`complete\` / \`rejected\`). The bridge-out hook switches the wallet to L2 internally so the EIP-712 signature matches; without this pause the auto-switch effect would yank the wallet back to L1 mid-sign and cause a chainId mismatch. When the tx settles, the effect re-fires and pulls the wallet back to the selected page network.

## Test plan
- [ ] Connect on L1 with a Safe smart wallet, open the Bridge tab, choose **Withdraw L2 → L1** with native asset, enter an amount, and submit
- [ ] Wallet should prompt to switch to L2 → sign the typed-data → tx should land on L2 (not be sent to the L1 builder)
- [ ] After the receipt the overlay should show **Complete**, the wallet should auto-switch back to L1, and the page should remain on the L1 Bridge tab
- [ ] Verify the L1 → L2 deposit and the swap flows still work without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)