### PR TITLE
feat(cross-chain-dex-ui): split bridge into L1 deposit and L2 withdraw tabs

### DIFF
--- a/packages/cross-chain-dex-ui/src/App.tsx
+++ b/packages/cross-chain-dex-ui/src/App.tsx
@@ -49,9 +49,10 @@ function AppContent() {
   const requiredChainId = selectedNetwork === 'l2' ? surgeL2Chain.id : surgeL1Chain.id;
   const networkSetupTarget = selectedNetwork === 'l2' ? 'l2' as const : 'l1' as const;
 
-  // When L2 is selected, force swap tab (no bridge/liquidity on L2)
+  // L2 only exposes Swap and Bridge (withdraw). If the user is on the
+  // Liquidity tab when switching to L2, fall back to Swap.
   useEffect(() => {
-    if (selectedNetwork === 'l2' && activeTab !== 'swap') {
+    if (selectedNetwork === 'l2' && activeTab === 'liquidity') {
       setActiveTab('swap');
     }
   }, [selectedNetwork, activeTab]);
@@ -114,7 +115,7 @@ function AppContent() {
   }, [smartWallet, ethBalance, usdcBalance, balancesLoading, hasShownFundModal, isLoading, l2WalletExists, showNetworkSetup, showWalletSetup, accountMode, selectedNetwork]);
 
   const availableTabs: ActiveTab[] = selectedNetwork === 'l2'
-    ? ['swap']
+    ? ['swap', 'bridge']
     : ['swap', 'liquidity', 'bridge'];
 
   return (
@@ -168,8 +169,9 @@ function AppContent() {
               onVenueChange={() => {}}
             />
           )}
-          {activeTab === 'bridge' && selectedNetwork === 'l1' && (
+          {activeTab === 'bridge' && (
             <BridgeCard
+              network={selectedNetwork}
               onSetupWallet={() => setShowWalletSetup(true)}
               onFundWallet={() => setShowFundWallet(true)}
             />

--- a/packages/cross-chain-dex-ui/src/components/BridgeCard.tsx
+++ b/packages/cross-chain-dex-ui/src/components/BridgeCard.tsx
@@ -1,135 +1,133 @@
-import { useState, useCallback, useMemo } from "react";
-import { parseUnits, formatUnits, Address } from "viem";
+import { useState, useCallback, useMemo, useEffect } from "react";
+import { parseUnits, formatUnits, Address, isAddress } from "viem";
+import { useAccount } from "wagmi";
 import { TokenInput } from "./TokenInput";
 import { useSmartWallet } from "../context/SmartWalletContext";
 import { useSharedTokenBalances } from "../context/SmartWalletContext";
-import { useL2TokenBalances } from "../hooks/useL2TokenBalances";
+import { useTokenBalances } from "../hooks/useTokenBalances";
 import { useUserOp } from "../hooks/useUserOp";
+import { useBridgeOutEoa } from "../hooks/useBridgeOutEoa";
 import { useSpendingLimit } from "../hooks/useSpendingLimit";
-import { ETH_TOKEN, USDC_TOKEN, L1_NATIVE_SYMBOL } from "../lib/constants";
+import { ETH_TOKEN, L1_NATIVE_SYMBOL, L1_CHAIN_NAME } from "../lib/constants";
+import { l1PublicClient, l2PublicClient } from "../lib/config";
 import { DisclaimerModal } from "./DisclaimerModal";
 import { useDisclaimer } from "../hooks/useDisclaimer";
 import { WarningBanner } from "./WarningBanner";
-import { BridgeDirection } from "../types";
-
-type BridgeToken = typeof L1_NATIVE_SYMBOL | "USDC";
 
 interface BridgeCardProps {
+  network: 'l1' | 'l2';
   onSetupWallet: () => void;
   onFundWallet?: () => void;
 }
 
-export function BridgeCard({ onSetupWallet, onFundWallet }: BridgeCardProps) {
-  const { smartWallet, isConnected, l2WalletExists, accountMode } = useSmartWallet();
-  const { ethBalance, usdcBalance } = useSharedTokenBalances();
-  const { ethBalance: l2EthBalance, usdcBalance: l2UsdcBalance } = useL2TokenBalances(smartWallet);
-  const { executeBridge, executeBridgeNative, executeBridgeOutNative, isPending } = useUserOp(accountMode);
+export function BridgeCard({ network, onSetupWallet, onFundWallet }: BridgeCardProps) {
+  const isL1 = network === 'l1';
+  const { smartWallet, isConnected, l2WalletExists, accountMode, setSelectedNetwork } = useSmartWallet();
+  const { address: eoaAddress } = useAccount();
+
+  // L1 deposit uses smart wallet's L1 balance; L2 withdraw uses EOA's L2 balance.
+  const smartWalletBalances = useSharedTokenBalances();
+  const eoaL2Balances = useTokenBalances(eoaAddress ?? null, 'l2');
+  const { ethBalance } = isL1 ? smartWalletBalances : eoaL2Balances;
+
+  const { executeBridgeNative, isPending: isUserOpPending } = useUserOp(accountMode);
+  const { initiate: initiateBridgeOut, isPending: isBridgeOutPending } = useBridgeOutEoa();
+  const isPending = isL1 ? isUserOpPending : isBridgeOutPending;
+
   const { hasExceededL2Limit, wouldExceed, recordSpending, remaining } = useSpendingLimit(smartWallet);
   const { isDisclaimerOpen, requireDisclaimer, onAccept, onCancel } = useDisclaimer();
 
-  const [direction, setDirection] = useState<BridgeDirection>("L1_TO_L2");
-  const [bridgeToken, setBridgeToken] = useState<BridgeToken>(L1_NATIVE_SYMBOL);
+  // Bridge currently only supports the native xDAI in both directions.
+  // USDC bridge-out (L2 -> L1) is not implemented at the contract layer.
   const [inputAmount, setInputAmount] = useState("");
   const [recipient, setRecipient] = useState("");
 
-  const isDeposit = direction === "L1_TO_L2";
-
-  const currentToken =
-    bridgeToken === L1_NATIVE_SYMBOL ? ETH_TOKEN : USDC_TOKEN;
-
   const amountIn = useMemo(() => {
     try {
-      return inputAmount ? parseUnits(inputAmount, currentToken.decimals) : 0n;
+      return inputAmount ? parseUnits(inputAmount, ETH_TOKEN.decimals) : 0n;
     } catch {
       return 0n;
     }
-  }, [inputAmount, currentToken.decimals]);
+  }, [inputAmount]);
 
-  // Use L1 balances for deposit, L2 balances for withdrawal
-  const currentBalance = isDeposit
-    ? (bridgeToken === L1_NATIVE_SYMBOL ? ethBalance : usdcBalance)
-    : (bridgeToken === L1_NATIVE_SYMBOL ? l2EthBalance : l2UsdcBalance);
+  const hasInsufficientBalance = amountIn > ethBalance;
+  const bridgeAmountUsd = amountIn > 0n ? Number(formatUnits(amountIn, ETH_TOKEN.decimals)) : 0;
+  const exceedsL2Limit = isL1 && (hasExceededL2Limit || (bridgeAmountUsd > 0 && wouldExceed(bridgeAmountUsd)));
 
-  const hasInsufficientBalance = amountIn > currentBalance;
-  const bridgeAmountUsd = amountIn > 0n ? Number(formatUnits(amountIn, currentToken.decimals)) : 0;
+  // Default recipient: the connected EOA on the destination chain.
+  const defaultRecipient = eoaAddress || "";
+  const effectiveRecipient = (recipient || defaultRecipient) as Address;
 
-  // Only apply spending limit checks for deposits
-  const exceedsL2Limit = isDeposit && (hasExceededL2Limit || (bridgeAmountUsd > 0 && wouldExceed(bridgeAmountUsd)));
+  // If the user types a custom recipient, check whether it's a contract on the
+  // destination chain — bridging to a non-receiving contract can strand funds.
+  const [recipientIsContract, setRecipientIsContract] = useState(false);
+  useEffect(() => {
+    setRecipientIsContract(false);
+    const trimmed = recipient.trim();
+    if (!trimmed || !isAddress(trimmed)) return;
+    let cancelled = false;
+    const destClient = isL1 ? l2PublicClient : l1PublicClient;
+    destClient
+      .getCode({ address: trimmed as Address })
+      .then((code) => {
+        if (!cancelled) setRecipientIsContract(!!code && code !== '0x');
+      })
+      .catch(() => { /* ignore network blips */ });
+    return () => { cancelled = true; };
+  }, [recipient, isL1]);
 
-  // For withdrawals, default recipient to smartWallet (not EOA)
-  const effectiveRecipient = (recipient || smartWallet || "") as Address;
+  const handleSubmit = useCallback(async () => {
+    if (amountIn === 0n) return;
 
-  // USDC bridge-out is not supported yet
-  const isWithdrawUSDC = !isDeposit && bridgeToken === "USDC";
-
-  const handleBridge = useCallback(async () => {
-    if (!smartWallet || amountIn === 0n) return;
-
-    let success: boolean;
-
-    if (!isDeposit) {
-      // Bridge-out: L2 → L1 (native only)
-      success = await executeBridgeOutNative({
-        amount: amountIn,
-        recipient: effectiveRecipient,
-        smartWallet,
-      });
-    } else if (bridgeToken === L1_NATIVE_SYMBOL) {
-      success = await executeBridgeNative({
-        amount: amountIn,
-        recipient: effectiveRecipient,
-        smartWallet,
-      });
+    let success = false;
+    if (isL1) {
+      if (!smartWallet) return;
+      success = await executeBridgeNative({ amount: amountIn, recipient: effectiveRecipient, smartWallet });
+      if (success) recordSpending(bridgeAmountUsd);
     } else {
-      success = await executeBridge({
-        amount: amountIn,
-        recipient: effectiveRecipient,
-        smartWallet,
-      });
+      if (!eoaAddress) return;
+      success = await initiateBridgeOut({ amount: amountIn, recipient: effectiveRecipient });
     }
 
-    if (success) {
-      if (isDeposit) recordSpending(bridgeAmountUsd);
-      setInputAmount("");
-    }
+    if (success) setInputAmount("");
   }, [
+    isL1,
     smartWallet,
+    eoaAddress,
     amountIn,
-    isDeposit,
-    bridgeToken,
-    bridgeAmountUsd,
     effectiveRecipient,
-    executeBridge,
+    bridgeAmountUsd,
     executeBridgeNative,
-    executeBridgeOutNative,
+    initiateBridgeOut,
     recordSpending,
   ]);
 
   const getButtonText = () => {
     if (isPending) return "Bridging...";
     if (!isConnected) return "Connect Wallet";
-    if (!smartWallet) return "Setup Smart Wallet First";
+    if (isL1 && !smartWallet) return "Setup Smart Wallet First";
+    if (isL1 && !l2WalletExists) return "Create L2 wallet first";
     if (!amountIn) return "Enter Amount";
-    if (isWithdrawUSDC) return "USDC withdrawal not supported yet";
-    if (isDeposit && hasExceededL2Limit) return "L2 deposit limit reached ($1)";
-    if (isDeposit && exceedsL2Limit) return `Exceeds $1 limit ($${remaining.toFixed(2)} left)`;
-    if (!isDeposit && !l2WalletExists) return "Create L2 wallet first";
+    if (isL1 && hasExceededL2Limit) return "L2 deposit limit reached ($1)";
+    if (isL1 && exceedsL2Limit) return `Exceeds $1 limit ($${remaining.toFixed(2)} left)`;
     if (hasInsufficientBalance) return "Insufficient Balance";
-    if (!isDeposit) return `Withdraw ${bridgeToken} to L1`;
-    return `Bridge ${bridgeToken} to L2`;
+    return isL1 ? `Bridge ${L1_NATIVE_SYMBOL} to L2` : `Withdraw ${L1_NATIVE_SYMBOL} to L1`;
   };
 
-  const needsL2WalletSetup = !isDeposit && !l2WalletExists && !!onFundWallet;
+  const needsL2WalletSetup = isL1 && !!smartWallet && !l2WalletExists && !!onFundWallet;
 
   const isDisabled =
     isPending ||
     !isConnected ||
-    !smartWallet ||
+    (isL1 && !smartWallet) ||
+    (isL1 && !l2WalletExists) ||
     !amountIn ||
     hasInsufficientBalance ||
-    exceedsL2Limit ||
-    isWithdrawUSDC ||
-    (!isDeposit && !l2WalletExists);
+    exceedsL2Limit;
+
+  const venueBadge = isL1
+    ? { label: 'Via Smart Account', cls: 'bg-surge-secondary/15 border-surge-secondary/50 text-surge-primary' }
+    : { label: 'Via EOA', cls: 'bg-surge-secondary/20 border-surge-secondary/60 text-surge-primary' };
 
   return (
     <div className="flex flex-col md:flex-row items-start gap-4 justify-center w-full relative z-10">
@@ -138,104 +136,68 @@ export function BridgeCard({ onSetupWallet, onFundWallet }: BridgeCardProps) {
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <span className="inline-block w-1 h-5 rounded-full bg-surge-secondary" />
-            <h2 className="text-lg font-semibold text-surge-text">Bridge</h2>
+            <h2 className="text-lg font-semibold text-surge-text">
+              {isL1 ? 'Deposit' : 'Withdraw'}
+            </h2>
           </div>
-          <span className="text-[11px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-full border bg-surge-secondary/15 border-surge-secondary/50 text-surge-primary">
-            Via Smart Account
+          <span className={`text-[11px] font-semibold uppercase tracking-wider px-2.5 py-1 rounded-full border ${venueBadge.cls}`}>
+            {venueBadge.label}
           </span>
         </div>
         <WarningBanner />
 
-        {/* Direction Toggle */}
-        <div className="flex gap-2">
-          <button
-            onClick={() => {
-              setDirection("L1_TO_L2");
-              setInputAmount("");
-            }}
-            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
-              isDeposit
-                ? "bg-surge-primary text-white shadow-sm"
-                : "bg-surge-card-hover text-surge-muted hover:text-surge-text border border-surge-border"
-            }`}
-          >
-            Deposit L1&rarr;L2
-          </button>
-          <button
-            onClick={() => {
-              setDirection("L2_TO_L1");
-              setInputAmount("");
-            }}
-            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
-              !isDeposit
-                ? "bg-surge-primary text-white shadow-sm"
-                : "bg-surge-card-hover text-surge-muted hover:text-surge-text border border-surge-border"
-            }`}
-          >
-            Withdraw L2&rarr;L1
-          </button>
-        </div>
-
-        {/* Token Selector */}
-        <div className="flex gap-2">
-          {([L1_NATIVE_SYMBOL, "USDC"] as BridgeToken[]).map((t) => (
-            <button
-              key={t}
-              onClick={() => {
-                setBridgeToken(t);
-                setInputAmount("");
-              }}
-              className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
-                bridgeToken === t
-                  ? "bg-surge-primary text-white shadow-sm"
-                  : "bg-surge-card-hover text-surge-muted hover:text-surge-text border border-surge-border"
-              }`}
-            >
-              {t}
-            </button>
-          ))}
-        </div>
-
-        {/* USDC withdrawal not supported notice */}
-        {isWithdrawUSDC && (
-          <div className="bg-red-50 border border-red-300 rounded-lg px-3 py-2 text-xs text-red-700">
-            USDC withdrawal (L2&rarr;L1) is not yet supported. Only native {L1_NATIVE_SYMBOL} withdrawals are available.
-          </div>
-        )}
+        {/* Cross-network notice */}
+        <button
+          type="button"
+          onClick={() => setSelectedNetwork(isL1 ? 'l2' : 'l1')}
+          className="w-full text-left bg-surge-card-hover border border-surge-border rounded-lg px-3 py-2 text-xs text-surge-muted hover:bg-surge-secondary/10 hover:border-surge-secondary/40 hover:text-surge-primary transition-colors"
+        >
+          {isL1
+            ? <>Need to withdraw L2 → L1? <span className="font-semibold text-surge-primary">Switch to Surge L2 →</span></>
+            : <>Need to deposit L1 → L2? <span className="font-semibold text-surge-primary">Switch to {L1_CHAIN_NAME} →</span></>}
+        </button>
 
         {/* Token Amount */}
         <TokenInput
-          token={currentToken}
+          token={ETH_TOKEN}
           amount={inputAmount}
           onAmountChange={setInputAmount}
-          balance={currentBalance}
+          balance={ethBalance}
           label="Amount"
         />
 
         {/* Recipient (optional) */}
         <div className="space-y-1">
           <label className="text-xs text-surge-muted">
-            {isDeposit ? "Recipient on L2 (optional)" : "Recipient on L1 (optional)"}
+            {isL1 ? "Recipient on L2 (optional)" : "Recipient on L1 (optional)"}
           </label>
           <input
             type="text"
             value={recipient}
             onChange={(e) => setRecipient(e.target.value)}
             placeholder={
-              smartWallet ? `Default: ${smartWallet.slice(0, 10)}...` : "0x..."
+              defaultRecipient ? `Default: ${defaultRecipient.slice(0, 10)}...` : "0x..."
             }
             className="w-full bg-surge-card-hover border border-surge-border rounded-lg px-3 py-2 text-sm text-surge-text placeholder-surge-muted/60 focus:outline-none focus:border-surge-secondary"
           />
+          {recipientIsContract && (
+            <div className="bg-red-50 border border-red-300 rounded-lg px-3 py-2 text-xs text-red-700 flex items-start gap-1.5 mt-1">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5 shrink-0 mt-0.5" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+              <span>This recipient is a contract on {isL1 ? "L2" : "L1"}. Funds may be stranded if it can't accept native transfers — double-check before sending.</span>
+            </div>
+          )}
         </div>
 
         {/* Bridge Button */}
         <button
           onClick={
-            isConnected && !smartWallet
+            isL1 && isConnected && !smartWallet
               ? onSetupWallet
               : needsL2WalletSetup
                 ? onFundWallet
-                : () => requireDisclaimer(handleBridge)
+                : () => requireDisclaimer(handleSubmit)
           }
           disabled={!needsL2WalletSetup && isDisabled}
           className={`w-full py-3 rounded-xl font-semibold text-base transition-all duration-200 ${
@@ -266,17 +228,13 @@ export function BridgeCard({ onSetupWallet, onFundWallet }: BridgeCardProps) {
           {/* Flow Visualization */}
           <div className="flex items-center justify-center gap-3 py-3">
             <div className="flex items-center gap-2 bg-surge-card-hover border border-surge-border px-3 py-2 rounded-lg">
-              <span className="text-xs text-surge-muted">{isDeposit ? "L1" : "L2"}</span>
-              <span className="text-sm text-surge-text font-medium">
-                {isDeposit ? (bridgeToken === L1_NATIVE_SYMBOL ? "Send" : "Lock") : "Send"}
-              </span>
+              <span className="text-xs text-surge-muted">{isL1 ? "L1" : "L2"}</span>
+              <span className="text-sm text-surge-text font-medium">Send</span>
             </div>
             <div className="text-surge-secondary">&rarr;</div>
             <div className="flex items-center gap-2 bg-surge-card-hover border border-surge-border px-3 py-2 rounded-lg">
-              <span className="text-xs text-surge-muted">{isDeposit ? "L2" : "L1"}</span>
-              <span className="text-sm text-surge-text font-medium">
-                {isDeposit ? (bridgeToken === L1_NATIVE_SYMBOL ? "Receive" : "Mint") : "Receive"}
-              </span>
+              <span className="text-xs text-surge-muted">{isL1 ? "L2" : "L1"}</span>
+              <span className="text-sm text-surge-text font-medium">Receive</span>
             </div>
           </div>
 
@@ -285,13 +243,13 @@ export function BridgeCard({ onSetupWallet, onFundWallet }: BridgeCardProps) {
             <div className="flex justify-between text-sm">
               <span className="text-surge-muted">You send</span>
               <span className="text-surge-text">
-                {formatUnits(amountIn, currentToken.decimals)} {bridgeToken}
+                {formatUnits(amountIn, ETH_TOKEN.decimals)} {L1_NATIVE_SYMBOL}
               </span>
             </div>
             <div className="flex justify-between text-sm">
               <span className="text-surge-muted">You receive</span>
               <span className="text-surge-text">
-                {formatUnits(amountIn, currentToken.decimals)} {bridgeToken} on {isDeposit ? "L2" : "L1"}
+                {formatUnits(amountIn, ETH_TOKEN.decimals)} {L1_NATIVE_SYMBOL} on {isL1 ? "L2" : "L1"}
               </span>
             </div>
             <div className="flex justify-between text-sm mt-1 pt-1 border-t border-surge-border">

--- a/packages/cross-chain-dex-ui/src/hooks/useBridgeOutEoa.ts
+++ b/packages/cross-chain-dex-ui/src/hooks/useBridgeOutEoa.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react';
+import { Address, encodeFunctionData, zeroAddress, Hex } from 'viem';
+import { useWalletClient } from 'wagmi';
+import { l2PublicClient } from '../lib/config';
+import { L2_BRIDGE, CHAIN_ID } from '../lib/constants';
+import { BridgeABI } from '../lib/contracts';
+import { useTxStatus } from '../context/TxStatusContext';
+
+interface BridgeOutParams {
+  amount: bigint;
+  recipient: Address;
+}
+
+/// Bridge native L2 funds back to L1 via a direct EOA tx to the L2 bridge.
+/// Mirrors the calldata produced by `buildBridgeOutNativeUserOps` but skips
+/// the Safe / L1 UserOp builder paths — on the L2 page the user signs from
+/// their EOA, so this is just a standard L2 transaction.
+export function useBridgeOutEoa() {
+  const { data: walletClient } = useWalletClient();
+  const { setTxStatus } = useTxStatus();
+  const [isPending, setIsPending] = useState(false);
+
+  const initiate = useCallback(
+    async ({ amount, recipient }: BridgeOutParams): Promise<boolean> => {
+      if (!walletClient) {
+        setTxStatus({ phase: 'rejected', errorMessage: 'Wallet not connected' });
+        return false;
+      }
+      setIsPending(true);
+      try {
+        setTxStatus({ phase: 'signing' });
+        const sender = walletClient.account.address;
+        const calldata = encodeFunctionData({
+          abi: BridgeABI,
+          functionName: 'sendMessage',
+          args: [{
+            id: 0n,
+            fee: 0n,
+            gasLimit: 1_000_000,
+            from: zeroAddress,
+            srcChainId: 0n,
+            srcOwner: sender,
+            destChainId: BigInt(CHAIN_ID),
+            destOwner: recipient,
+            to: recipient,
+            value: amount,
+            data: '0x' as Hex,
+          }],
+        });
+        const txHash = await walletClient.sendTransaction({
+          to: L2_BRIDGE,
+          value: amount,
+          data: calldata,
+          chain: walletClient.chain,
+          account: walletClient.account,
+        });
+        setTxStatus({ phase: 'sequencing' });
+        await l2PublicClient.waitForTransactionReceipt({ hash: txHash });
+        setTxStatus({ phase: 'complete', txHash });
+        setIsPending(false);
+        return true;
+      } catch (err) {
+        const raw = err instanceof Error ? err.message : 'Bridge withdrawal failed';
+        const msg = raw.includes('rejected') || raw.includes('denied')
+          ? 'Transaction rejected by user'
+          : raw.split(/[.\n]/)[0].trim().slice(0, 160);
+        setTxStatus({ phase: 'rejected', errorMessage: msg });
+        setIsPending(false);
+        return false;
+      }
+    },
+    [walletClient, setTxStatus]
+  );
+
+  return { initiate, isPending };
+}


### PR DESCRIPTION
## Summary
Bridge previously lived only on L1 with a Deposit/Withdraw direction toggle and required a Safe smart wallet for the L2 → L1 path. Move the withdraw flow to its own L2 page so each network exposes only the operation that makes sense for its account context (smart wallet on L1, EOA on L2).

- **Bridge tab now visible on both networks.** \`App.tsx\` adds \`'bridge'\` to the L2 available tabs and passes \`selectedNetwork\` into BridgeCard.
- **BridgeCard** takes a \`network\` prop. On L1 it shows **Deposit** only (Safe via \`executeBridgeNative\`); on L2 it shows **Withdraw** only (direct EOA tx via the new \`useBridgeOutEoa\` hook). The direction toggle and USDC selector are removed — only native xDAI is supported in either direction. A clickable banner *"Switch to Surge L2 / L1"* jumps the network for users on the wrong side.
- **New \`useBridgeOutEoa\` hook** submits \`L2_BRIDGE.sendMessage\` as a direct EOA transaction on L2 (mirrors the calldata \`buildBridgeOutNativeUserOps\` produces) and walks the overlay through \`signing → sequencing → complete\` on the L2 receipt — no Safe, no L1 UserOp builder.
- **Default deposit recipient** on L1 is now the connected EOA (was the smart wallet). When the user enters a custom recipient, \`getCode\` is called on the destination chain; if the address is a contract a red warning banner appears under the input (*"Funds may be stranded if it can't accept native transfers"*).

## Test plan
- [ ] On L1, open the Bridge tab → only the Deposit form is shown, default recipient prefilled with the EOA. Submit a deposit and verify funds land on the recipient on L2.
- [ ] Enter a known L2 contract address as the recipient and verify the red contract-warning banner appears.
- [ ] Click the "Switch to Surge L2" banner — page should jump to L2 and Bridge tab should switch to the Withdraw form.
- [ ] On L2, submit a withdrawal — wallet should sign on L2 and the overlay should run \`signing → sequencing → complete\` without going through the L1 builder.
- [ ] Confirm Liquidity tab still only renders on L1 (Bridge fallback no longer kicks the user to Swap when on L2 with Bridge selected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)