### PR TITLE
Migrate witness tests to `proof_call`

### DIFF
--- a/packages/taiko-client/driver/proof_call_test.go
+++ b/packages/taiko-client/driver/proof_call_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 // executionWitness mirrors the NMC Witness type (camelCase JSON, hex-encoded byte arrays).
+// It is returned nested under the "witness" field of a proof_call result.
 type executionWitness struct {
 	Codes   []string `json:"codes"`
 	State   []string `json:"state"`
@@ -18,18 +19,35 @@ type executionWitness struct {
 	Headers []string `json:"headers"`
 }
 
-// callRequest is the JSON-RPC call request object for debug_executionWitnessCall.
+// proofCallResult is the proof_call response envelope (CallResultWithProof on the NMC side): the EVM
+// return data, an optional in-VM error, and the execution witness captured during the call. An in-VM
+// failure (revert, out-of-gas, ...) does NOT fail the RPC — it is reported in Error while the witness
+// is still captured, so a verifier can re-prove the failure.
+type proofCallResult struct {
+	Result  string           `json:"result"`
+	Error   *proofCallError  `json:"error,omitempty"`
+	Witness executionWitness `json:"witness"`
+}
+
+// proofCallError is the in-payload error object proof_call returns on an in-VM failure.
+type proofCallError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    string `json:"data,omitempty"`
+}
+
+// callRequest is the JSON-RPC call object (a partial transaction) passed to proof_call.
 type callRequest struct {
 	To   string `json:"to"`
 	Data string `json:"data,omitempty"`
 	Gas  string `json:"gas,omitempty"`
 }
 
-// TestDebugExecutionWitnessCallBasic calls debug_executionWitnessCall on L2 NMC
-// with a simple call and verifies the witness structure is returned.
-func (s *DriverTestSuite) TestDebugExecutionWitnessCallBasic() {
+// TestProofCallBasic calls proof_call on L2 NMC with a simple call and verifies the
+// witness structure is returned.
+func (s *DriverTestSuite) TestProofCallBasic() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("debug_executionWitnessCall only available on NMC")
+		s.T().Skip("proof_call only available on NMC")
 	}
 
 	// Advance L2 past genesis so we have a valid block to query.
@@ -39,36 +57,37 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallBasic() {
 	s.Nil(err)
 	s.Greater(l2Head.Number.Uint64(), uint64(0))
 
-	// Call debug_executionWitnessCall with a simple read of the Taiko anchor contract.
+	// Call proof_call with a simple read of the Taiko anchor contract.
 	// Any valid address works — the witness captures all state accessed during the call.
 	taikoAnchor := common.HexToAddress("0x1670010000000000000000000000000000010001")
 	blockHex := "0x" + l2Head.Number.Text(16)
 
-	var witness executionWitness
+	var result proofCallResult
 	err = s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{
 			To:  taikoAnchor.Hex(),
 			Gas: "0x100000",
 		},
 		blockHex,
 	)
-	s.Nil(err, "debug_executionWitnessCall should succeed")
+	s.Nil(err, "proof_call should succeed")
 
 	// The witness should have state nodes — the EVM reads the account's nonce/balance/codeHash
 	// and any storage accessed during the call.
+	witness := result.Witness
 	s.NotEmpty(witness.State, "witness should contain state trie nodes")
 	s.T().Logf("Witness: %d state nodes, %d codes, %d keys, %d headers",
 		len(witness.State), len(witness.Codes), len(witness.Keys), len(witness.Headers))
 }
 
-// TestDebugExecutionWitnessCallWithData calls debug_executionWitnessCall with
-// actual calldata (a function selector) and verifies the witness captures code.
-func (s *DriverTestSuite) TestDebugExecutionWitnessCallWithData() {
+// TestProofCallWithData calls proof_call with actual calldata (a function selector)
+// and verifies the witness captures code.
+func (s *DriverTestSuite) TestProofCallWithData() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("debug_executionWitnessCall only available on NMC")
+		s.T().Skip("proof_call only available on NMC")
 	}
 
 	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().EventSyncer())
@@ -77,15 +96,15 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallWithData() {
 	s.Nil(err)
 
 	// Call with the paused() selector (0x5c975abb) on the Taiko anchor contract.
-	// Even if it reverts, the witness captures all accessed state.
+	// Even if it reverts, proof_call still succeeds at the RPC layer and captures the witness.
 	taikoAnchor := common.HexToAddress("0x1670010000000000000000000000000000010001")
 	blockHex := "0x" + l2Head.Number.Text(16)
 
-	var witness executionWitness
+	var result proofCallResult
 	err = s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{
 			To:   taikoAnchor.Hex(),
 			Data: "0x5c975abb",
@@ -93,7 +112,8 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallWithData() {
 		},
 		blockHex,
 	)
-	s.Nil(err, "debug_executionWitnessCall should succeed even if call reverts internally")
+	s.Nil(err, "proof_call should succeed even if the call reverts internally")
+	witness := result.Witness
 	s.NotEmpty(witness.State, "witness should contain state trie nodes")
 
 	// When calling a contract with code, the witness should capture the bytecode.
@@ -102,20 +122,20 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallWithData() {
 		len(witness.State), len(witness.Codes), len(witness.Keys), len(witness.Headers))
 }
 
-// TestDebugExecutionWitnessCallGenesisBlock verifies that requesting a witness
-// for the genesis block returns an error.
-func (s *DriverTestSuite) TestDebugExecutionWitnessCallGenesisBlock() {
+// TestProofCallGenesisBlock verifies that requesting a witness for the genesis
+// block returns an error (genesis has no parent header to walk back from).
+func (s *DriverTestSuite) TestProofCallGenesisBlock() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("debug_executionWitnessCall only available on NMC")
+		s.T().Skip("proof_call only available on NMC")
 	}
 
 	taikoAnchor := common.HexToAddress("0x1670010000000000000000000000000000010001")
 
-	var witness executionWitness
+	var result proofCallResult
 	err := s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{To: taikoAnchor.Hex(), Gas: "0x100000"},
 		"0x0", // genesis block
 	)
@@ -123,20 +143,20 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallGenesisBlock() {
 	s.T().Logf("Genesis block error (expected): %v", err)
 }
 
-// TestDebugExecutionWitnessCallNonExistentBlock verifies that requesting a witness
-// for a block that doesn't exist returns an error.
-func (s *DriverTestSuite) TestDebugExecutionWitnessCallNonExistentBlock() {
+// TestProofCallNonExistentBlock verifies that requesting a witness for a block
+// that doesn't exist returns an error.
+func (s *DriverTestSuite) TestProofCallNonExistentBlock() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("debug_executionWitnessCall only available on NMC")
+		s.T().Skip("proof_call only available on NMC")
 	}
 
 	taikoAnchor := common.HexToAddress("0x1670010000000000000000000000000000010001")
 
-	var witness executionWitness
+	var result proofCallResult
 	err := s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{To: taikoAnchor.Hex(), Gas: "0x100000"},
 		"0xFFFFFF", // block 16777215, far in the future
 	)
@@ -144,33 +164,33 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallNonExistentBlock() {
 	s.T().Logf("Non-existent block error (expected): %v", err)
 }
 
-// TestDebugExecutionWitnessCallLatestBlock verifies that "latest" block parameter works.
-func (s *DriverTestSuite) TestDebugExecutionWitnessCallLatestBlock() {
+// TestProofCallLatestBlock verifies that the "latest" block parameter works.
+func (s *DriverTestSuite) TestProofCallLatestBlock() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("debug_executionWitnessCall only available on NMC")
+		s.T().Skip("proof_call only available on NMC")
 	}
 
 	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().EventSyncer())
 
 	taikoAnchor := common.HexToAddress("0x1670010000000000000000000000000000010001")
 
-	var witness executionWitness
+	var result proofCallResult
 	err := s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{To: taikoAnchor.Hex(), Gas: "0x100000"},
 		"latest",
 	)
-	s.Nil(err, "debug_executionWitnessCall should work with 'latest'")
-	s.NotEmpty(witness.State, "witness should contain state trie nodes")
+	s.Nil(err, "proof_call should work with 'latest'")
+	s.NotEmpty(result.Witness.State, "witness should contain state trie nodes")
 }
 
-// TestDebugExecutionWitnessCallToEOA verifies that calling an EOA (no code)
-// still returns a valid witness — just with account state, no codes.
-func (s *DriverTestSuite) TestDebugExecutionWitnessCallToEOA() {
+// TestProofCallToEOA verifies that calling an EOA (no code) still returns a valid
+// witness — just with account state, no codes.
+func (s *DriverTestSuite) TestProofCallToEOA() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("debug_executionWitnessCall only available on NMC")
+		s.T().Skip("proof_call only available on NMC")
 	}
 
 	s.ProposeAndInsertValidBlock(s.p, s.d.ChainSyncer().EventSyncer())
@@ -182,16 +202,17 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallToEOA() {
 	randomEOA := common.HexToAddress("0x9999999999999999999999999999999999999999")
 	blockHex := "0x" + l2Head.Number.Text(16)
 
-	var witness executionWitness
+	var result proofCallResult
 	err = s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{To: randomEOA.Hex(), Gas: "0x100000"},
 		blockHex,
 	)
-	s.Nil(err, "debug_executionWitnessCall to EOA should succeed")
+	s.Nil(err, "proof_call to EOA should succeed")
 	// Witness should have state (sender + receiver account nodes) but likely no codes.
+	witness := result.Witness
 	s.NotEmpty(witness.State, "witness should contain account state nodes even for EOA")
 	s.T().Logf("EOA witness: %d state nodes, %d codes", len(witness.State), len(witness.Codes))
 }
@@ -200,11 +221,11 @@ func (s *DriverTestSuite) TestDebugExecutionWitnessCallToEOA() {
 // 1. Deploy L1 view contract
 // 2. Send L2 tx calling L1STATICCALL precompile
 // 3. Propose block, sync, verify receipt
-// 4. Generate execution witness for a call on that L2 block
+// 4. Generate execution witness (via proof_call) for a call on that L2 block
 // 5. Verify the witness captures state
 func (s *DriverTestSuite) TestL1STATICCALLEndToEndWithWitness() {
 	if os.Getenv("L2_NODE") != testutils.L2NodeNMC {
-		s.T().Skip("L1STATICCALL + debug_executionWitnessCall only supported on NMC")
+		s.T().Skip("L1STATICCALL + proof_call only supported on NMC")
 	}
 
 	expectedValue := common.BigToHash(big.NewInt(0x42424242))
@@ -248,15 +269,16 @@ func (s *DriverTestSuite) TestL1STATICCALLEndToEndWithWitness() {
 	taikoAnchor := common.HexToAddress("0x1670010000000000000000000000000000010001")
 	blockHex := "0x" + l2Head.Number.Text(16)
 
-	var witness executionWitness
+	var result proofCallResult
 	err = s.RPCClient.L2.CallContext(
 		context.Background(),
-		&witness,
-		"debug_executionWitnessCall",
+		&result,
+		"proof_call",
 		callRequest{To: taikoAnchor.Hex(), Gas: "0x100000"},
 		blockHex,
 	)
-	s.Nil(err, "debug_executionWitnessCall should succeed on block with L1STATICCALL tx")
+	s.Nil(err, "proof_call should succeed on block with L1STATICCALL tx")
+	witness := result.Witness
 	s.NotEmpty(witness.State, "witness should contain state trie nodes")
 	s.T().Logf("E2E witness: %d state nodes, %d codes, %d keys, %d headers",
 		len(witness.State), len(witness.Codes), len(witness.Keys), len(witness.Headers))

--- a/packages/taiko-client/internal/docker/nodes/nmc/taiko-devnet.cfg
+++ b/packages/taiko-client/internal/docker/nodes/nmc/taiko-devnet.cfg
@@ -27,7 +27,7 @@
     "EnginePort": 8551,
     "EngineEnabledModules": ["engine"],
     "JwtSecretFile": "/host/jwt.hex",
-    "EnabledModules": ["eth", "net", "web3", "txpool", "debug", "taiko", "admin", "subscribe"]
+    "EnabledModules": ["eth", "net", "web3", "txpool", "debug", "taiko", "admin", "subscribe", "proof"]
   },
   "Network": {
     "DiscoveryPort": 30303,


### PR DESCRIPTION
https://github.com/NethermindEth/nethermind/pull/11732 replaced the RPC `debug_executionWitnessCall` with `proof_call`. Our `surge-shasta` driver integration tests still call the old method, so they've been failing on every Nethermind PR that touches `Nethermind.Taiko/**` since that merged on Jun 11. 

This migrates the harness to `proof_call`. 